### PR TITLE
Harden pnpm bootstrap in CI workflows

### DIFF
--- a/.github/workflows/frontend-tests.yml
+++ b/.github/workflows/frontend-tests.yml
@@ -9,6 +9,7 @@ jobs:
     runs-on: ubuntu-latest
     env:
       ROADMAP_STEP_PATH: ${{ vars.ROADMAP_STEP_PATH }}
+      PNPM_VERSION: '9'
     steps:
       - uses: actions/checkout@v4
       - name: Detect pnpm workspace
@@ -46,13 +47,19 @@ jobs:
           cache: pnpm
           cache-dependency-path: ${{ steps.detect_pnpm.outputs.lock-path }}
       - name: Set up pnpm
+        if: ${{ steps.detect_pnpm.outputs.has-pnpm == 'true' }}
         uses: pnpm/action-setup@v4
         with:
-          version: 9
+          version: ${{ env.PNPM_VERSION }}
           run_install: false
       - name: Enable corepack
+        if: ${{ steps.detect_pnpm.outputs.has-pnpm == 'true' }}
         run: corepack enable
+      - name: Prepare pnpm via corepack
+        if: ${{ steps.detect_pnpm.outputs.has-pnpm == 'true' }}
+        run: corepack prepare pnpm@${{ env.PNPM_VERSION }} --activate
       - name: Show pnpm version
+        if: ${{ steps.detect_pnpm.outputs.has-pnpm == 'true' }}
         run: pnpm --version
       - name: Install dependencies
         if: ${{ steps.detect_pnpm.outputs.has-pnpm == 'true' }}

--- a/.github/workflows/guards.yml
+++ b/.github/workflows/guards.yml
@@ -9,6 +9,7 @@ jobs:
     runs-on: ubuntu-latest
     env:
       ROADMAP_STEP_PATH: ${{ vars.ROADMAP_STEP_PATH }}
+      PNPM_VERSION: '9'
     steps:
       - uses: actions/checkout@v4
       - name: Detect pnpm workspace
@@ -17,17 +18,27 @@ jobs:
         run: |
           Set-StrictMode -Version Latest
           $lock = Get-ChildItem -Path . -Filter 'pnpm-lock.yaml' -File -Recurse | Sort-Object FullName | Select-Object -First 1
+          $hasProject = $false
           $projectDir = '.'
           $lockPath = 'pnpm-lock.yaml'
           if ($lock) {
+            $projectDir = $lock.DirectoryName
+            $packageJson = Join-Path $projectDir 'package.json'
+            if (Test-Path $packageJson) {
+              $hasProject = $true
+            }
             $relativeLock = [System.IO.Path]::GetRelativePath((Get-Location).Path, $lock.FullName)
             $lockPath = ($relativeLock -replace '\\', '/')
-            $relativeDir = [System.IO.Path]::GetRelativePath((Get-Location).Path, $lock.DirectoryName)
+            $relativeDir = [System.IO.Path]::GetRelativePath((Get-Location).Path, $projectDir)
             if (-not $relativeDir -or $relativeDir -eq '') {
               $relativeDir = '.'
             }
             $projectDir = ($relativeDir -replace '\\', '/')
+          } else {
+            $projectDir = '.'
           }
+          $hasValue = $hasProject.ToString().ToLower()
+          "has-pnpm=$hasValue" | Out-File -FilePath $env:GITHUB_OUTPUT -Encoding utf8 -Append
           "project-dir=$projectDir" | Out-File -FilePath $env:GITHUB_OUTPUT -Encoding utf8 -Append
           "lock-path=$lockPath" | Out-File -FilePath $env:GITHUB_OUTPUT -Encoding utf8 -Append
       - uses: actions/setup-node@v4
@@ -36,13 +47,19 @@ jobs:
           cache: pnpm
           cache-dependency-path: ${{ steps.detect_pnpm.outputs.lock-path }}
       - name: Set up pnpm
+        if: ${{ steps.detect_pnpm.outputs.has-pnpm == 'true' }}
         uses: pnpm/action-setup@v4
         with:
-          version: 9
+          version: ${{ env.PNPM_VERSION }}
           run_install: false
       - name: Enable corepack
+        if: ${{ steps.detect_pnpm.outputs.has-pnpm == 'true' }}
         run: corepack enable
+      - name: Prepare pnpm via corepack
+        if: ${{ steps.detect_pnpm.outputs.has-pnpm == 'true' }}
+        run: corepack prepare pnpm@${{ env.PNPM_VERSION }} --activate
       - name: Show pnpm version
+        if: ${{ steps.detect_pnpm.outputs.has-pnpm == 'true' }}
         run: pnpm --version
       - name: Setup Python
         uses: actions/setup-python@v5

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## 2025-09-24
+- Renforcement du bootstrap pnpm dans les workflows Node avec detection conditionnelle et fallback corepack.
+- Mise a jour du guard CI pour exposer l'etat du workspace pnpm.
+- Ref: docs/roadmap/step-05.md
+
 ## 2025-09-23
 - Creation du hub agent et des sous-agents.
 - Ajout des guards PowerShell et workflows CI.


### PR DESCRIPTION
## Summary
- guard pnpm setup in CI and add a corepack fallback so pnpm is always available when a workspace exists
- expose the pnpm workspace flag to the guards job and document the change in the changelog

## Changes
- add a shared `PNPM_VERSION` environment variable and conditional pnpm bootstrap steps in `frontend-tests.yml`
- align pnpm detection in `guards.yml`, add corepack preparation, and wire the same conditions
- append a changelog entry for the hardened pnpm bootstrap

## Testing
- `tools/guards/run_all_guards.ps1` *(not run: PowerShell is unavailable in the execution environment)*

## Risk
- Low; updates are limited to CI workflows and documentation.

## Rollback
- Revert this PR to restore the previous workflow definitions.

## Roadmap Ref
- docs/roadmap/step-05.md

## Checklist
- [x] Code changes reviewed self-check
- [x] Documentation updated if needed
- [ ] Tests added or updated where necessary

------
https://chatgpt.com/codex/tasks/task_e_68d276d2a44c8330b1f42c944844ce8c