### PR TITLE
fix: install pnpm in frontend workflow

### DIFF
--- a/.github/workflows/frontend-tests.yml
+++ b/.github/workflows/frontend-tests.yml
@@ -46,6 +46,8 @@ jobs:
           node-version: 20
           cache: pnpm
           cache-dependency-path: ${{ steps.detect_pnpm.outputs.lock-path }}
+      - name: Install pnpm
+        run: npm install -g pnpm
       - name: Set up pnpm
         if: ${{ steps.detect_pnpm.outputs.has-pnpm == 'true' }}
         uses: pnpm/action-setup@v4


### PR DESCRIPTION
## Summary
- install pnpm globally in the frontend-tests workflow to ensure the binary exists when the job runs

## Changes
- add an explicit npm-based pnpm installation step prior to pnpm usage in the CI pipeline

## Testing
- not run (workflow-only change)

## Risk
- Low: only affects the frontend GitHub Actions workflow execution order.

## Rollback
- Revert this commit.

## Roadmap Ref
- docs/roadmap/step-05.md

## Checklist
- [x] I have linked the roadmap reference.
- [ ] I have run the relevant tests locally.


------
https://chatgpt.com/codex/tasks/task_e_68d2797a6b9c833098c2a415ab7f374f