### PR TITLE
Fix Node setup when pnpm workspace is absent

### DIFF
--- a/.github/workflows/frontend-tests.yml
+++ b/.github/workflows/frontend-tests.yml
@@ -41,11 +41,18 @@ jobs:
           "has-pnpm=$hasValue" | Out-File -FilePath $env:GITHUB_OUTPUT -Encoding utf8 -Append
           "project-dir=$projectDir" | Out-File -FilePath $env:GITHUB_OUTPUT -Encoding utf8 -Append
           "lock-path=$lockPath" | Out-File -FilePath $env:GITHUB_OUTPUT -Encoding utf8 -Append
-      - uses: actions/setup-node@v4
+      - name: Setup Node
+        if: ${{ steps.detect_pnpm.outputs.has-pnpm == 'true' }}
+        uses: actions/setup-node@v4
         with:
           node-version: 20
           cache: pnpm
           cache-dependency-path: ${{ steps.detect_pnpm.outputs.lock-path }}
+      - name: Setup Node (no pnpm workspace)
+        if: ${{ steps.detect_pnpm.outputs.has-pnpm != 'true' }}
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
       - name: Install pnpm
         run: npm install -g pnpm
       - name: Set up pnpm

--- a/.github/workflows/guards.yml
+++ b/.github/workflows/guards.yml
@@ -41,11 +41,18 @@ jobs:
           "has-pnpm=$hasValue" | Out-File -FilePath $env:GITHUB_OUTPUT -Encoding utf8 -Append
           "project-dir=$projectDir" | Out-File -FilePath $env:GITHUB_OUTPUT -Encoding utf8 -Append
           "lock-path=$lockPath" | Out-File -FilePath $env:GITHUB_OUTPUT -Encoding utf8 -Append
-      - uses: actions/setup-node@v4
+      - name: Setup Node
+        if: ${{ steps.detect_pnpm.outputs.has-pnpm == 'true' }}
+        uses: actions/setup-node@v4
         with:
           node-version: 20
           cache: pnpm
           cache-dependency-path: ${{ steps.detect_pnpm.outputs.lock-path }}
+      - name: Setup Node (no pnpm workspace)
+        if: ${{ steps.detect_pnpm.outputs.has-pnpm != 'true' }}
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
       - name: Set up pnpm
         if: ${{ steps.detect_pnpm.outputs.has-pnpm == 'true' }}
         uses: pnpm/action-setup@v4


### PR DESCRIPTION
## Summary
- guard the cached Node.js setup in the frontend workflow so it only runs when a pnpm workspace is detected
- apply the same conditional Node.js setup in the guards workflow to avoid cache failures when pnpm files are missing

## Testing
- not run (PowerShell 7 is unavailable in the execution environment)


------
https://chatgpt.com/codex/tasks/task_e_68d27a5f119883309e028153449bec02