### PR TITLE
Fix roadmap guard fallback

### DIFF
--- a/tools/guards/ensure_roadmap_ref.ps1
+++ b/tools/guards/ensure_roadmap_ref.ps1
@@ -77,6 +77,21 @@ function Get-PrContext {
   }
 }
 
+function Resolve-StepPathFromRoadmap {
+  $roadmapReadme = Join-Path 'docs' 'roadmap' 'README.md'
+  if (-not (Test-Path $roadmapReadme)) { return $null }
+  try {
+    $content = Get-Content $roadmapReadme -Raw
+  } catch {
+    return $null
+  }
+  $match = [regex]::Match($content, 'step-([0-9]{2})\.md')
+  if ($match.Success -and $match.Value) {
+    return "docs/roadmap/$($match.Value)"
+  }
+  return $null
+}
+
 $prContext = Get-PrContext
 if (-not $StepPath -and $prContext -and $prContext.Body) {
   $match = [regex]::Match($prContext.Body, $refPattern)
@@ -100,6 +115,14 @@ if (-not $StepPath) {
 if (-not $StepPath -and $env:ROADMAP_STEP_PATH) {
   $StepPath = $env:ROADMAP_STEP_PATH
   Write-Info "Detected StepPath from env var: $StepPath"
+}
+
+if (-not $StepPath) {
+  $resolved = Resolve-StepPathFromRoadmap
+  if ($resolved) {
+    $StepPath = $resolved
+    Write-Info "Detected StepPath from docs/roadmap/README.md: $StepPath"
+  }
 }
 
 if (-not $StepPath) {


### PR DESCRIPTION
## Summary
- add a docs/roadmap/README.md fallback in ensure_roadmap_ref.ps1 when no explicit step reference is found
- log the detected step to make troubleshooting easier

## Testing
- `pwsh ./tools/guards/run_all_guards.ps1` *(fails: command not found in container environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d27bba6f6c8330ab8ad967899eda0f