### PR TITLE
Fix GH token export in guards workflow

### DIFF
--- a/.github/workflows/guards.yml
+++ b/.github/workflows/guards.yml
@@ -74,6 +74,8 @@ jobs:
           python-version: "3.12"
       - name: Inject roadmap reference (auto-detect)
         shell: pwsh
+        env:
+          GH_TOKEN: ${{ github.token }}
         run: |
           if ($env:ROADMAP_STEP_PATH) {
             ./tools/guards/ensure_roadmap_ref.ps1 -StepPath $env:ROADMAP_STEP_PATH
@@ -82,6 +84,8 @@ jobs:
           }
       - name: Run guards
         shell: pwsh
+        env:
+          GH_TOKEN: ${{ github.token }}
         run: |
           ./tools/guards/run_all_guards.ps1
 


### PR DESCRIPTION
## Summary
- ensure the guards workflow authenticates GitHub CLI commands

## Changes
- add the GitHub token environment variable to the roadmap injection and guard execution steps

## Testing
- not run (pwsh unavailable in local container)

## Risk
- Low

## Rollback
- Revert commit 1976a57

## Roadmap Ref
- docs/roadmap/step-05.md

## Checklist
- [ ] Backend tests (pytest)
- [ ] Frontend tests (vitest)
- [x] Workflow updated


------
https://chatgpt.com/codex/tasks/task_e_68d27cdf7b348330808f4d009de041a6