### PR TITLE
chore: tolerate gh pr edit failures in roadmap guard

### DIFF
--- a/tools/guards/ensure_roadmap_ref.ps1
+++ b/tools/guards/ensure_roadmap_ref.ps1
@@ -152,11 +152,24 @@ if ($prContext) {
     } else {
       $newBody = $refLine
     }
-    try {
-      gh pr edit $prContext.Number --body "$newBody" | Out-Null
+    $ghUpdateSucceeded = $false
+    if ($gh) {
+      try {
+        gh pr edit $prContext.Number --body "$newBody" | Out-Null
+        if ($LASTEXITCODE -eq 0 -and $?) {
+          $ghUpdateSucceeded = $true
+        }
+      } catch {
+        $ghUpdateSucceeded = $false
+      }
+    }
+
+    if ($ghUpdateSucceeded) {
       Write-Info 'Appended roadmap ref to PR body.'
-    } catch {
+      $global:LASTEXITCODE = 0
+    } else {
       Write-Info 'Failed to append to PR body. Falling back to empty commit.'
+      $global:LASTEXITCODE = 0
       $message = Get-CommitMessage
       if (-not ($message -and $message.Contains($refLine))) {
         Write-Info 'Creating empty commit with roadmap ref...'


### PR DESCRIPTION
## Summary
- ensure the roadmap guard checks gh pr edit exit codes before reporting success
- fall back to empty commits when PR editing is not permitted and reset the exit code

## Testing
- `pwsh -NoLogo -NoProfile -Command "./tools/guards/run_all_guards.ps1"` *(fails: pwsh not available in container)*

------
https://chatgpt.com/codex/tasks/task_e_68d27e14461c8330afb558704772778f