### PR TITLE
Fix ensure_roadmap_ref guard fallback commit identity

### DIFF
--- a/tools/guards/ensure_roadmap_ref.ps1
+++ b/tools/guards/ensure_roadmap_ref.ps1
@@ -17,6 +17,20 @@ $gh = Get-Command gh -ErrorAction SilentlyContinue
 $commitMessage = ''
 $gitMessageLoaded = $false
 
+function Invoke-RoadmapRefEmptyCommit {
+  param([string]$RefLine)
+
+  $message = "chore(ci): ensure roadmap reference`n`n$RefLine"
+  $args = @(
+    '-c', 'user.name=roadmap-guard',
+    '-c', 'user.email=roadmap-guard@users.noreply.github.com',
+    '-c', 'commit.gpgsign=false',
+    'commit', '--allow-empty', '-m', $message
+  )
+
+  & git @args | Out-Null
+}
+
 if ($StepPath) {
   $StepPath = $StepPath.Trim()
   if ($StepPath) {
@@ -173,7 +187,7 @@ if ($prContext) {
       $message = Get-CommitMessage
       if (-not ($message -and $message.Contains($refLine))) {
         Write-Info 'Creating empty commit with roadmap ref...'
-        git commit --allow-empty -m "chore(ci): ensure roadmap reference`n`n$refLine" | Out-Null
+        Invoke-RoadmapRefEmptyCommit -RefLine $refLine
       } else {
         Write-Info 'Latest commit already contains roadmap ref. No action required.'
       }
@@ -185,6 +199,6 @@ if ($prContext) {
     Write-Info 'Latest commit already contains roadmap ref.'
   } else {
     Write-Info 'Creating empty commit with roadmap ref...'
-    git commit --allow-empty -m "chore(ci): ensure roadmap reference`n`n$refLine" | Out-Null
+    Invoke-RoadmapRefEmptyCommit -RefLine $refLine
   }
 }


### PR DESCRIPTION
## Summary
- ensure the roadmap guard sets a git identity before creating fallback commits

## Changes
- add a helper that wraps `git commit` with a guard-specific author
- reuse the helper for every empty commit the guard may create

## Testing
- ⚠️ `pwsh -NoLogo -File tools/guards/run_all_guards.ps1` *(fails locally: `pwsh` is not installed in the container image)*

## Risk
- Low

## Rollback
- Revert this commit.

## Roadmap Ref
- docs/roadmap/step-05.md

## Checklist
- [x] Ready for review
- [x] Roadmap reference included


------
https://chatgpt.com/codex/tasks/task_e_68d27f5ac11c833087420fd0778cf893