### PR TITLE
docs: prepare roadmap step 07 for persistence

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@
 - `tools/guards/docs_guard.ps1`
 
 ## Roadmap
-- Etape courante: [docs/roadmap/step-06.md](docs/roadmap/step-06.md)
+- Etape courante: [docs/roadmap/step-07.md](docs/roadmap/step-07.md)
 - Sommaire: [docs/roadmap/README.md](docs/roadmap/README.md)
 
 ## Backend FastAPI

--- a/docs/codex/last_output.json
+++ b/docs/codex/last_output.json
@@ -1,17 +1,14 @@
 {
-  "timestamp": "2025-09-25T09:00:00Z",
+  "timestamp": "2025-09-26T09:00:00Z",
   "plan": [
-    "Initialiser un noyau backend FastAPI avec un pyproject et les dependances essentielles (fastapi, uvicorn, pydantic).",
-    "Structurer le package src/backend/app avec un point d'entree main.py, configuration settings et routes de sante/planification.",
-    "Ajouter un premier module de domaine pour la gestion des artistes et disponibilites ainsi que des schemas de transfert de donnees.",
-    "Configurer pytest + coverage, ecrire des tests de fumee (endpoint de sante, creation de planning) et viser >= 70% de couverture.",
-    "Mettre a jour la CI backend (workflow backend-tests) pour installer les dependances projet, lancer pytest et publier les rapports.",
-    "Documenter les commandes de developpement et mettre a jour README, AGENT backend et changelog a la cloture."
+    "Installer SQLAlchemy 2.x et Alembic et configurer backend.db pour la persistence.",
+    "Definir les models persistants (Artist, Availability, Planning, Assignment) et aligner les schemas Pydantic.",
+    "Brancher create_planning sur la couche persistence pour enregistrer et relire les plannings.",
+    "Exposer GET /api/v1/plannings et GET /api/v1/plannings/{planning_id} pour consulter les plannings.",
+    "Ecrire les tests (pytest + SQLite en memoire) couvrant la creation et la lecture de plannings.",
+    "Mettre a jour README, AGENT backend, workflows CI et changelog apres livraison."
   ],
-  "last_update": "2025-09-25T09:00:00Z",
-  "status": "delivered",
-  "notes": [
-    "Backend FastAPI operationnel avec endpoints health/plannings et couverture >= 70 %.",
-    "Workflow CI backend-tests installe le package via pyproject, genere coverage.xml et archive l'artefact."
-  ]
+  "last_update": "2025-09-26T09:00:00Z",
+  "status": "planned",
+  "notes": []
 }

--- a/docs/roadmap/README.md
+++ b/docs/roadmap/README.md
@@ -1,8 +1,9 @@
 # Roadmap
 
 ## Current Step
-- [STEP 06](./step-06.md)
+- [STEP 07](./step-07.md)
 
 ## History
+- [STEP 06](./step-06.md)
 - [STEP 05](./step-05.md)
 - [STEP 04](./step-04.md)

--- a/docs/roadmap/step-07.md
+++ b/docs/roadmap/step-07.md
@@ -1,0 +1,36 @@
+# STEP 07 - Persistence SQLAlchemy du planning
+
+## SUMMARY
+Introduire une couche de persistence relationnelle pour les artistes et plannings afin de conserver les donnees au-dela de la requete FastAPI.
+
+## GOALS
+- Ajouter SQLAlchemy 2.x et Alembic au projet backend pour gerer les schemas et migrations.
+- Definir des models persistants (artistes, disponibilites, plannings, affectations) alignes avec les schemas Pydantic existants.
+- Mettre en place un module `backend.db` pour l'initialisation de l'engine, la gestion de session et la configuration via variables d'environnement.
+- Adapter le service de domaine `create_planning` pour enregistrer le planning genere et permettre sa consultation ulterieure.
+- Exposer de nouveaux endpoints REST pour lister les plannings enregistres et consulter un planning par identifiant.
+
+## CHANGES
+- Mise a jour de `pyproject.toml` pour inclure SQLAlchemy, Alembic et les dependances utilitaires (typing-extensions, sqlalchemy-utils si necessaire).
+- Creation d'un repertoire `src/backend/db/` contenant l'engine, la session et les utilitaires de migrations.
+- Ajout d'un module `src/backend/models/` avec les entites persistantes et leurs relations.
+- Evolution de `src/backend/main.py` et des routes pour orchestrer la persistence et exposer les nouveaux endpoints.
+- Extension de la batterie de tests avec une base SQLite en memoire, y compris des tests d'integration pour les nouveaux endpoints.
+- Mise a jour de la documentation (README, AGENT backend) et du changelog lors de la validation.
+
+## TESTS
+- Execution de `pytest` sur une base SQLite en memoire couvrant les operations de creation et de lecture des plannings.
+- Verification de la generation d'un rapport de couverture et du respect du seuil de 70 %.
+
+## CI
+- Adapter le workflow `backend-tests` pour initialiser la base SQLite, executer les migrations Alembic et lancer les tests.
+- Publier le rapport de couverture et s'assurer que les artefacts sont archives.
+
+## ARCHIVE
+- Mettre a jour `docs/CHANGELOG.md`, `docs/codex/last_output.json` et la roadmap une fois l'etape livree.
+- Documenter les commandes d'initialisation de la base et des migrations dans le README backend.
+
+## RESULTS
+- A remplir apres livraison de l'etape.
+
+VALIDATE? no


### PR DESCRIPTION
## Summary
- Prepare the roadmap for step 07 focused on introducing SQLAlchemy persistence for artists and plannings.

## Changes
- Added `docs/roadmap/step-07.md` detailing goals, expected changes, tests, CI and archival tasks for the persistence step.
- Updated the roadmap index and main README to mark step 07 as the current iteration.
- Refreshed `docs/codex/last_output.json` with the new execution plan tied to the persistence objectives.

## Testing
- Not run (documentation-only update).

## Risk
- Low

## Rollback
- Revert this commit.

## Roadmap Ref
- docs/roadmap/step-07.md

## Checklist
- [x] Documentation updated
- [ ] Added or updated tests
- [ ] Guards executed


------
https://chatgpt.com/codex/tasks/task_e_68d286cc6b6c8330b98ae8b234ff2764