### PR TITLE
docs: prepare step 08 roadmap iteration

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@
 - `tools/guards/docs_guard.ps1`
 
 ## Roadmap
-- Etape courante: [docs/roadmap/step-07.md](docs/roadmap/step-07.md)
+- Etape courante: [docs/roadmap/step-08.md](docs/roadmap/step-08.md)
 - Sommaire: [docs/roadmap/README.md](docs/roadmap/README.md)
 
 ## Backend FastAPI

--- a/docs/codex/last_output.json
+++ b/docs/codex/last_output.json
@@ -1,16 +1,16 @@
 {
-  "timestamp": "2025-09-27T09:00:00Z",
+  "timestamp": "2025-09-28T09:00:00Z",
   "plan": [
-    "Installer SQLAlchemy 2.x et Alembic et configurer backend.db pour la persistence.",
-    "Definir les models persistants (Artist, Availability, Planning, Assignment) et aligner les schemas Pydantic.",
-    "Brancher create_planning sur la couche persistence pour enregistrer et relire les plannings.",
-    "Exposer GET /api/v1/plannings et GET /api/v1/plannings/{planning_id} pour consulter les plannings.",
-    "Ecrire les tests (pytest + SQLite en memoire) couvrant la creation et la lecture de plannings.",
-    "Mettre a jour README, AGENT backend, workflows CI et changelog apres livraison."
+    "Aligner schemas Pydantic et models SQLAlchemy pour le CRUD artistes/disponibilites.",
+    "Ajouter les endpoints FastAPI POST/GET/PUT/DELETE /artists avec validations et gestion des erreurs.",
+    "Factoriser les services domaine pour synchroniser artistes, disponibilites et plannings persistes.",
+    "Generer une migration Alembic garantissant unicite des creneaux et suppression en cascade.",
+    "Etendre les tests pytest (SQLite en memoire) couvrant les scenarios CRUD artistes et la regeneration de planning.",
+    "Mettre a jour la documentation backend, agents et exemples d'appels API."
   ],
-  "last_update": "2025-09-27T09:00:00Z",
-  "status": "delivered",
+  "last_update": "2025-09-28T09:00:00Z",
+  "status": "planned",
   "notes": [
-    "SQLAlchemy persistence et endpoints de lecture exposes avec couverture de tests."
+    "Iteration focalisee sur la gestion des artistes et la consolidation de la persistence."
   ]
 }

--- a/docs/roadmap/README.md
+++ b/docs/roadmap/README.md
@@ -1,9 +1,10 @@
 # Roadmap
 
 ## Current Step
-- [STEP 07](./step-07.md)
+- [STEP 08](./step-08.md)
 
 ## History
+- [STEP 07](./step-07.md)
 - [STEP 06](./step-06.md)
 - [STEP 05](./step-05.md)
 - [STEP 04](./step-04.md)

--- a/docs/roadmap/step-08.md
+++ b/docs/roadmap/step-08.md
@@ -1,0 +1,36 @@
+# STEP 08 - Gestion des artistes et disponibilites
+
+## SUMMARY
+Ouvrir l'API a la gestion complete des artistes en permettant la creation, la mise a jour et la consultation des disponibilites ainsi que leur exploitation dans le planning.
+
+## GOALS
+- Introduire des endpoints REST pour gerer les artistes et leurs disponibilites (CRUD minimal).
+- Synchroniser les schemas Pydantic, les models SQLAlchemy et les migrations Alembic associees.
+- Factoriser une couche de services domaine pour la maintenance des artistes et leur reutilisation dans la generation de planning.
+- Documenter les nouveaux flux (API, exemples JSON) et preparer les jeux de donnees pour tests et demonstration.
+
+## CHANGES
+- Etendre `backend.domain` et `backend.models` afin d'integrer les operations CRUD artistes/disponibilites.
+- Ajouter les routes FastAPI (`POST/GET /artists`, `GET /artists/{id}`, `PUT /artists/{id}`, `DELETE /artists/{id}`) et gerer les erreurs fonctionnelles.
+- Produire une revision Alembic couvrant les contraintes (unicite disponibilites, suppression en cascade) et ajuster la configuration database.
+- Renforcer les tests d'integration avec une base SQLite en memoire et des fixtures dediees aux artistes.
+- Mettre a jour la documentation backend (README, AGENT backend) et les scripts de demarrage pour illustrer les nouveaux endpoints.
+
+## TESTS
+- Execution de `pytest` avec SQLite en memoire, couvrant les operations CRUD artistes et la generation de planning post-synchronisation.
+- Verification du rapport de couverture (>= 70 %) et ajout de tests de regression sur la selection des creneaux.
+
+## CI
+- Adapter le workflow `backend-tests` pour initialiser les donnees de reference avant les tests d'integration.
+- Publier les artefacts de couverture et suivre la regression sur les routes artistes.
+
+## ARCHIVE
+- Mise a jour de `docs/CHANGELOG.md`, `docs/codex/last_output.json` et de la roadmap une fois l'etape livree.
+- Archivage d'exemples de payloads artistes/planning dans `docs/` pour reference produit.
+
+## RESULTS
+- API FastAPI expose des operations completes pour la gestion des artistes et disponibilites.
+- Les routes planning reutilisent la persistence artistes sans duplication de donnees.
+- Suite de tests enrichie validant les scenarios CRUD et la generation de planning.
+
+VALIDATE? no


### PR DESCRIPTION
## Summary
- documenter l'etape 08 de la roadmap pour la gestion CRUD des artistes et disponibilites
- mettre a jour les sommaires roadmap et README principal
- actualiser le plan d'execution dans docs/codex/last_output.json

## Testing
- not run (documentation-only changes)


------
https://chatgpt.com/codex/tasks/task_e_68d29265f1f08330b42831fa34130111