### PR TITLE
feat: add artist CRUD API and docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,19 @@ uvicorn backend.main:app --reload
   ```
 - Variable `BACKEND_SQLALCHEMY_ECHO=true` pour activer les logs SQL durant le debug.
 
+### Endpoints REST
+- `GET /api/v1/health` expose l'etat du service.
+- `POST /api/v1/artists` cree un artiste et synchronise ses disponibilites.
+- `GET /api/v1/artists` liste les artistes persistes tries par nom.
+- `GET /api/v1/artists/{artist_id}` retourne un artiste par identifiant.
+- `PUT /api/v1/artists/{artist_id}` remplace les informations et disponibilites de l'artiste.
+- `DELETE /api/v1/artists/{artist_id}` supprime un artiste et ses disponibilites.
+- `POST /api/v1/plannings` genere un planning a partir des artistes fournis.
+- `GET /api/v1/plannings` liste les plannings persistes.
+- `GET /api/v1/plannings/{planning_id}` retourne un planning par identifiant.
+
+Des exemples de requetes et reponses JSON sont disponibles dans [docs/backend/api.md](docs/backend/api.md).
+
 ### Tests et couverture
 ```bash
 pytest

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## 2025-09-28
+- CRUD complet des artistes expose via FastAPI (routes `/api/v1/artists`).
+- Synchronisation des services domaine, schemas Pydantic et contraintes Alembic pour les disponibilites.
+- Documentation API et tests d'integration enrichis autour de SQLite en memoire.
+- Ref: docs/roadmap/step-08.md
+
 ## 2025-09-27
 - Ajout de la persistence SQLAlchemy avec models `backend.models` et configuration `backend.db`.
 - Creation des migrations Alembic initiales et documentation des commandes d'execution.

--- a/docs/agents/AGENT.backend.md
+++ b/docs/agents/AGENT.backend.md
@@ -26,6 +26,14 @@
 - Schemas Pydantic: `Availability`, `Artist`, `PlanningCreate`, `PlanningResponse`.
 - Service de domaine `create_planning` selectionne le premier creneau disponible par artiste et leve `PlanningError` sinon.
 
+## Evolution Step 08
+- Ajout des schemas `ArtistCreate` et `ArtistUpdate` pour differencier les payloads d'ecriture.
+- Services domaine exposes pour gerer le CRUD artistes (`create_artist`, `list_artists`, `get_artist`, `update_artist`, `delete_artist`).
+- Contrainte d'unicite `(artist_id, start, end)` sur la table `availabilities` via migration Alembic `20240928_02`.
+- Routes REST `POST/GET/GET{id}/PUT/DELETE /api/v1/artists` avec gestion des erreurs 404/409.
+- Documentation des exemples JSON dans `docs/backend/api.md`.
+- Tests d'integration et fixtures dediees aux artistes (`tests/backend/test_artists.py`).
+
 ## Conventions API
 - Prefixer les routes par `/api/v1` (ajuster si version change).
 - Utiliser schemas Pydantic pour requetes et reponses, valider les champs obligatoires.

--- a/docs/backend/api.md
+++ b/docs/backend/api.md
@@ -1,0 +1,130 @@
+# Backend API
+
+Cette page illustre les principaux flux REST exposes par le backend FastAPI.
+
+## Base
+- URL racine: `http://localhost:8000/api/v1`
+- Format: JSON UTF-8
+- Authentification: aucune (developpement)
+
+## Gestion des artistes
+
+### Creation d'un artiste
+```http
+POST /api/v1/artists
+Content-Type: application/json
+
+{
+  "name": "Alice",
+  "availabilities": [
+    {"start": "2024-05-10T09:00:00", "end": "2024-05-10T10:00:00"},
+    {"start": "2024-05-11T14:00:00", "end": "2024-05-11T15:00:00"}
+  ]
+}
+```
+
+Reponse (201 Created):
+```json
+{
+  "id": "1b6f0f32-6ba2-4f83-9c58-3f748d6a3e62",
+  "name": "Alice",
+  "availabilities": [
+    {"start": "2024-05-10T09:00:00", "end": "2024-05-10T10:00:00"},
+    {"start": "2024-05-11T14:00:00", "end": "2024-05-11T15:00:00"}
+  ]
+}
+```
+
+### Mise a jour d'un artiste
+```http
+PUT /api/v1/artists/1b6f0f32-6ba2-4f83-9c58-3f748d6a3e62
+Content-Type: application/json
+
+{
+  "name": "Alice Cooper",
+  "availabilities": [
+    {"start": "2024-05-12T10:00:00", "end": "2024-05-12T12:00:00"}
+  ]
+}
+```
+
+Reponse (200 OK):
+```json
+{
+  "id": "1b6f0f32-6ba2-4f83-9c58-3f748d6a3e62",
+  "name": "Alice Cooper",
+  "availabilities": [
+    {"start": "2024-05-12T10:00:00", "end": "2024-05-12T12:00:00"}
+  ]
+}
+```
+
+### Liste des artistes
+```http
+GET /api/v1/artists
+```
+
+Extrait de reponse (200 OK):
+```json
+[
+  {
+    "id": "1b6f0f32-6ba2-4f83-9c58-3f748d6a3e62",
+    "name": "Alice Cooper",
+    "availabilities": [
+      {"start": "2024-05-12T10:00:00", "end": "2024-05-12T12:00:00"}
+    ]
+  },
+  {
+    "id": "9fd9d689-53f6-4a61-9c51-09536bbf1509",
+    "name": "Bob",
+    "availabilities": [
+      {"start": "2024-05-10T11:00:00", "end": "2024-05-10T12:00:00"}
+    ]
+  }
+]
+```
+
+### Suppression d'un artiste
+```http
+DELETE /api/v1/artists/9fd9d689-53f6-4a61-9c51-09536bbf1509
+```
+
+Reponse: 204 No Content
+
+## Generation de planning
+
+Les plannings reutilisent les artistes persistes. Exemple:
+
+```http
+POST /api/v1/plannings
+Content-Type: application/json
+
+{
+  "event_date": "2024-05-12",
+  "artists": [
+    {
+      "id": "1b6f0f32-6ba2-4f83-9c58-3f748d6a3e62",
+      "name": "Alice Cooper",
+      "availabilities": [
+        {"start": "2024-05-12T10:00:00", "end": "2024-05-12T12:00:00"}
+      ]
+    }
+  ]
+}
+```
+
+Reponse (201 Created):
+```json
+{
+  "planning_id": "4c3a6d60-9a52-4c47-8961-cf944aacd187",
+  "event_date": "2024-05-12",
+  "assignments": [
+    {
+      "artist_id": "1b6f0f32-6ba2-4f83-9c58-3f748d6a3e62",
+      "slot": {"start": "2024-05-12T10:00:00", "end": "2024-05-12T12:00:00"}
+    }
+  ]
+}
+```
+
+Ces exemples servent de base pour constituer des jeux de donnees de demonstration et pour alimenter les tests d'integration sur SQLite en memoire.

--- a/docs/codex/last_output.json
+++ b/docs/codex/last_output.json
@@ -8,9 +8,11 @@
     "Etendre les tests pytest (SQLite en memoire) couvrant les scenarios CRUD artistes et la regeneration de planning.",
     "Mettre a jour la documentation backend, agents et exemples d'appels API."
   ],
-  "last_update": "2025-09-28T09:00:00Z",
-  "status": "planned",
+  "last_update": "2025-09-28T15:00:00Z",
+  "status": "completed",
   "notes": [
-    "Iteration focalisee sur la gestion des artistes et la consolidation de la persistence."
+    "CRUD artistes expose avec FastAPI et contrainte Alembic sur les disponibilites.",
+    "Tests pytest (SQLite) couvrant creation, mise a jour et suppression d'artistes.",
+    "Documentation API publiee dans docs/backend/api.md."
   ]
 }

--- a/docs/roadmap/step-08.md
+++ b/docs/roadmap/step-08.md
@@ -29,8 +29,8 @@ Ouvrir l'API a la gestion complete des artistes en permettant la creation, la mi
 - Archivage d'exemples de payloads artistes/planning dans `docs/` pour reference produit.
 
 ## RESULTS
-- API FastAPI expose des operations completes pour la gestion des artistes et disponibilites.
-- Les routes planning reutilisent la persistence artistes sans duplication de donnees.
-- Suite de tests enrichie validant les scenarios CRUD et la generation de planning.
+- API FastAPI expose le CRUD complet `/api/v1/artists` avec validations et erreurs 404/409.
+- Contrainte d'unicite Alembic sur les disponibilites et services domaine mutualises pour planning/artistes.
+- Tests pytest sur SQLite en memoire couvrant les scenarios CRUD artistes et les plannings.
 
-VALIDATE? no
+VALIDATE? yes

--- a/src/backend/db/migrations/versions/20240928_02_artist_availability_constraints.py
+++ b/src/backend/db/migrations/versions/20240928_02_artist_availability_constraints.py
@@ -1,0 +1,23 @@
+"""Ensure artist availability slots are unique."""
+
+from __future__ import annotations
+
+from alembic import op
+
+
+revision = "20240928_02"
+down_revision = "20240926_01"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.create_unique_constraint(
+        op.f("uq_availabilities_artist_id"),
+        "availabilities",
+        ["artist_id", "start", "end"],
+    )
+
+
+def downgrade() -> None:
+    op.drop_constraint(op.f("uq_availabilities_artist_id"), "availabilities", type_="unique")

--- a/src/backend/domain/__init__.py
+++ b/src/backend/domain/__init__.py
@@ -1,24 +1,42 @@
 """Domain models and services for the planning backend."""
 
-from .artists import Artist, Availability
+from .artists import Artist, ArtistCreate, ArtistUpdate, Availability
 from .planning import PlanningAssignment, PlanningCreate, PlanningResponse
 from .services import (
+    ArtistConflictError,
+    ArtistError,
+    ArtistNotFoundError,
     PlanningError,
     PlanningNotFoundError,
+    create_artist,
     create_planning,
+    delete_artist,
+    get_artist,
     get_planning,
+    list_artists,
     list_plannings,
+    update_artist,
 )
 
 __all__ = [
     "Artist",
+    "ArtistCreate",
+    "ArtistUpdate",
     "Availability",
     "PlanningAssignment",
     "PlanningCreate",
     "PlanningResponse",
+    "ArtistError",
+    "ArtistNotFoundError",
+    "ArtistConflictError",
     "PlanningError",
     "PlanningNotFoundError",
+    "create_artist",
     "create_planning",
+    "delete_artist",
+    "get_artist",
     "get_planning",
+    "list_artists",
     "list_plannings",
+    "update_artist",
 ]

--- a/src/backend/domain/artists.py
+++ b/src/backend/domain/artists.py
@@ -39,4 +39,32 @@ class Artist(BaseModel):
     )
 
 
-__all__ = ["Artist", "Availability"]
+class ArtistCreate(BaseModel):
+    """Payload used to create a new artist."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    name: str = Field(..., min_length=1, description="Public name of the artist")
+    availabilities: List[Availability] = Field(
+        default_factory=list,
+        description="Declared availabilities for the artist",
+    )
+    id: UUID | None = Field(
+        default=None,
+        description="Optional identifier for the artist. Generated when omitted.",
+    )
+
+
+class ArtistUpdate(BaseModel):
+    """Payload used to update an existing artist."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    name: str = Field(..., min_length=1, description="Public name of the artist")
+    availabilities: List[Availability] = Field(
+        default_factory=list,
+        description="Declared availabilities for the artist",
+    )
+
+
+__all__ = ["Artist", "Availability", "ArtistCreate", "ArtistUpdate"]

--- a/src/backend/models/artist.py
+++ b/src/backend/models/artist.py
@@ -6,7 +6,7 @@ from datetime import datetime
 from typing import List
 from uuid import UUID, uuid4
 
-from sqlalchemy import DateTime, ForeignKey, String
+from sqlalchemy import DateTime, ForeignKey, String, UniqueConstraint
 from sqlalchemy.orm import Mapped, mapped_column, relationship
 from sqlalchemy.types import Uuid
 
@@ -32,6 +32,7 @@ class Availability(Base):
     """Availability slot linked to an artist."""
 
     __tablename__ = "availabilities"
+    __table_args__ = (UniqueConstraint("artist_id", "start", "end"),)
 
     id: Mapped[UUID] = mapped_column(Uuid, primary_key=True, default=uuid4)
     artist_id: Mapped[UUID] = mapped_column(

--- a/tests/backend/conftest.py
+++ b/tests/backend/conftest.py
@@ -3,8 +3,11 @@
 from __future__ import annotations
 
 import os
-from collections.abc import AsyncIterator
+from collections.abc import AsyncIterator, Callable
+from datetime import datetime, timedelta
+from uuid import uuid4
 
+import pytest
 import pytest_asyncio
 from httpx import ASGITransport, AsyncClient
 
@@ -22,3 +25,32 @@ async def async_client() -> AsyncIterator[AsyncClient]:
     transport = ASGITransport(app=app)
     async with AsyncClient(transport=transport, base_url="http://testserver") as client:
         yield client
+
+
+@pytest.fixture
+def artist_payload_factory() -> Callable[..., dict[str, object]]:
+    """Return a factory producing artist payloads with generated slots."""
+
+    def _factory(
+        name: str = "Alice",
+        *,
+        base: datetime | None = None,
+        slots: int = 1,
+        include_id: bool = False,
+    ) -> dict[str, object]:
+        start_time = base or datetime(2024, 5, 10, 9, 0)
+        availabilities = []
+        for index in range(slots):
+            slot_start = start_time + timedelta(hours=2 * index)
+            availabilities.append(
+                {
+                    "start": slot_start.isoformat(),
+                    "end": (slot_start + timedelta(hours=1)).isoformat(),
+                }
+            )
+        payload: dict[str, object] = {"name": name, "availabilities": availabilities}
+        if include_id:
+            payload["id"] = str(uuid4())
+        return payload
+
+    return _factory

--- a/tests/backend/test_artists.py
+++ b/tests/backend/test_artists.py
@@ -1,0 +1,117 @@
+"""Integration tests covering the artist CRUD API."""
+
+from __future__ import annotations
+
+from uuid import uuid4
+
+import pytest
+
+
+@pytest.mark.asyncio
+async def test_create_artist_persists_and_returns_payload(async_client, artist_payload_factory) -> None:
+    """Posting a new artist should store it and return the representation."""
+
+    payload = artist_payload_factory(name="Zelda", slots=2)
+
+    response = await async_client.post("/api/v1/artists", json=payload)
+    body = response.json()
+
+    assert response.status_code == 201
+    assert body["name"] == "Zelda"
+    assert len(body["availabilities"]) == 2
+
+    artist_id = body["id"]
+    fetch = await async_client.get(f"/api/v1/artists/{artist_id}")
+    assert fetch.status_code == 200
+    assert fetch.json() == body
+
+
+@pytest.mark.asyncio
+async def test_list_artists_returns_ordered_items(async_client, artist_payload_factory) -> None:
+    """Listing artists should return them ordered alphabetically by name."""
+
+    await async_client.post("/api/v1/artists", json=artist_payload_factory(name="Charlie"))
+    await async_client.post("/api/v1/artists", json=artist_payload_factory(name="Alice"))
+
+    response = await async_client.get("/api/v1/artists")
+    body = response.json()
+
+    assert response.status_code == 200
+    assert [item["name"] for item in body] == ["Alice", "Charlie"]
+
+
+@pytest.mark.asyncio
+async def test_put_artist_replaces_availabilities(async_client, artist_payload_factory) -> None:
+    """Updating an artist should replace the stored availabilities set."""
+
+    creation = await async_client.post("/api/v1/artists", json=artist_payload_factory(slots=2))
+    artist_id = creation.json()["id"]
+
+    update_payload = {
+        "name": "Alice Updated",
+        "availabilities": [
+            {
+                "start": "2024-05-11T10:00:00",
+                "end": "2024-05-11T11:00:00",
+            }
+        ],
+    }
+
+    update = await async_client.put(f"/api/v1/artists/{artist_id}", json=update_payload)
+    body = update.json()
+
+    assert update.status_code == 200
+    assert body["name"] == "Alice Updated"
+    assert len(body["availabilities"]) == 1
+    assert body["availabilities"][0]["start"] == "2024-05-11T10:00:00"
+
+    fetch = await async_client.get(f"/api/v1/artists/{artist_id}")
+    assert fetch.json()["availabilities"] == body["availabilities"]
+
+
+@pytest.mark.asyncio
+async def test_delete_artist_removes_resource(async_client, artist_payload_factory) -> None:
+    """Deleting an artist should cascade to its availabilities."""
+
+    creation = await async_client.post("/api/v1/artists", json=artist_payload_factory())
+    artist_id = creation.json()["id"]
+
+    deletion = await async_client.delete(f"/api/v1/artists/{artist_id}")
+    assert deletion.status_code == 204
+
+    fetch = await async_client.get(f"/api/v1/artists/{artist_id}")
+    assert fetch.status_code == 404
+
+
+@pytest.mark.asyncio
+async def test_post_artist_with_existing_id_returns_conflict(async_client, artist_payload_factory) -> None:
+    """Creating an artist with an existing identifier should return 409."""
+
+    payload = artist_payload_factory(include_id=True)
+    await async_client.post("/api/v1/artists", json=payload)
+
+    response = await async_client.post("/api/v1/artists", json=payload)
+    body = response.json()
+
+    assert response.status_code == 409
+    assert body["detail"].startswith("Artist")
+
+
+@pytest.mark.asyncio
+async def test_unknown_artist_operations_return_404(async_client) -> None:
+    """Operations targeting an unknown artist should return 404."""
+
+    random_id = str(uuid4())
+
+    read = await async_client.get(f"/api/v1/artists/{random_id}")
+    assert read.status_code == 404
+
+    update_payload = {
+        "name": "Ghost",
+        "availabilities": [],
+    }
+    update = await async_client.put(f"/api/v1/artists/{random_id}", json=update_payload)
+    assert update.status_code == 404
+
+    delete = await async_client.delete(f"/api/v1/artists/{random_id}")
+    assert delete.status_code == 404


### PR DESCRIPTION
## Summary
- expose artist CRUD endpoints alongside planning routes
- enforce availability uniqueness and share artist services with planning features
- document the new API flows and refresh roadmap/changelog artifacts

## Changes
- extend domain services with artist CRUD helpers and Alembic migration for unique slots
- wire FastAPI routes for POST/GET/PUT/DELETE /api/v1/artists with error handling
- add artist integration tests, payload fixtures, and backend API documentation
- update roadmap status, changelog entry, and codex notes for step 08

## Testing
- `pytest`

## Risk
- Medium: new persistence paths and HTTP handlers for artist data

## Rollback
- Revert this commit and re-run migrations to previous head

## Roadmap Ref
- docs/roadmap/step-08.md

## Checklist
- [x] Tests pass locally
- [x] Documentation updated
- [x] Roadmap artifact updated

------
https://chatgpt.com/codex/tasks/task_e_68d29413bcc08330a33f77b1ad18009f