### PR TITLE
docs: add roadmap step 13 Observabilite et alerting

### DIFF
--- a/docs/roadmap/step-13.md
+++ b/docs/roadmap/step-13.md
@@ -1,0 +1,18 @@
+# STEP 13 - Observabilite et alerting
+
+## CONTEXTE
+Les modules audit et conformite sont en production. Pour aligner la plateforme avec les exigences NFR de la spec fonctionnelle v0.1, nous devons maintenant instrumenter l ensemble du SaaS afin de detecter rapidement les erreurs (5xx), surveiller la latence des flux planning/paie/materiel et piloter les jobs recurrents.
+
+## OBJECTIFS
+- Instrumenter les services backend, jobs ETL et connecteurs avec des traces correlees (ex. OpenTelemetry) et des logs structures conservant les identifiants RGPD/audit requis.
+- Exposer des metriques normalisees (latence API, erreurs 5xx, delai sync ICS, jobs paie/materiel) via un endpoint Prometheus et livrer des tableaux de bord pre-configures.
+- Mettre en place des alertes temps reel (PagerDuty/Slack/email) couvrant erreurs 5xx, saturation des files, derives de latence (>200 ms) et echecs de jobs critiques.
+- Documenter les runbooks SRE (triage, escalade, mitigation) et les budgets SLO (uptime, RPO 24h, RTO 4h) relies aux alertes et metriques.
+
+## ACCEPTATION
+- Chaque requete API et job critique produit une trace correlee (id requete, utilisateur, organisation) consultable depuis le tableau de bord central.
+- Les metriques principales (latence p95, taux erreurs, delais sync, backlog jobs) sont exposees, historisees et visualisees dans des dashboards partages.
+- Au moins trois regles d alerte (erreurs 5xx, latence planning, job ETL en echec) declenchent une notification verifiable vers les canaux definis.
+- Les runbooks et objectifs SLO/RPO/RTO sont documentes dans la base de connaissance et references dans la roadmap/changelog.
+
+VALIDATE? no


### PR DESCRIPTION
Ref: docs/roadmap/step-13.md

## Summary
- add the next roadmap step covering observabilite and alerting expectations from the spec

## Changes
- create docs/roadmap/step-13.md with contexte, objectifs, acceptation, validation marker

## Testing
- Not Run (pwsh not available in container to execute guards)

## Checklist
* [ ] Spec ajoutee/maj: docs/specs/spec-fonctionnelle-v0.1.md
* [ ] Agents referencent la SUT (SUT: docs/specs/spec-fonctionnelle-v0.1.md)
* [ ] Guards OK (docs_guard, roadmap_guard)
* [ ] Tests et lint OK

------
https://chatgpt.com/codex/tasks/task_e_68d2f6b539808330823061e891fdae8c