### PR TITLE
docs(roadmap): add step-02 projects and missions

### DIFF
--- a/docs/roadmap/ROADMAP.readme.md
+++ b/docs/roadmap/ROADMAP.readme.md
@@ -1,7 +1,7 @@
 # Roadmap
 
 ## Current Step
-- [STEP 01](./step-01.md)
+- [STEP 02](./step-02.md)
 
 ## History
-- A completer apres validation d'etapes precedentes.
+- [STEP 01](./step-01.md)

--- a/docs/roadmap/step-02.md
+++ b/docs/roadmap/step-02.md
@@ -1,0 +1,37 @@
+# STEP 02 - Projects and missions foundations
+
+## CONTEXT
+
+* Roadmap step aligned with spec modules 3.2 (Projects) and 3.3 (Missions reutilisables) to enable WF-01 end-to-end planning.
+* Auth and RBAC baseline from step 01 is available, enabling scoped project ownership and role-based permissions.
+* Early delivery unlocks shared entities for planning, availability, and future payroll workflows defined in sections 3.4, 3.6, and 3.7.
+
+## OBJECTIVES
+
+* Implement backend domain for projects and reusable missions with persistence, validation, and RBAC-ready APIs.
+* Provide frontend management screens to create and maintain projects, associate venues, and catalogue mission templates.
+* Ensure workflows and data models satisfy WF-01 acceptance criteria on project setup and mission reuse.
+
+## CHANGES
+
+* Backend: SQLAlchemy models, Pydantic schemas, CRUD services, and FastAPI routers for Project, Venue linkage, Mission templates, and tags; Alembic migrations with constraints matching spec section 2.
+* Backend: RBAC policies covering project/mission scopes, unit and integration tests targeting >=70% coverage for the new domain, seed fixtures for WF-01 scenarios.
+* Frontend: React views for project list/detail and mission catalogue with forms, validation, and optimistic updates; shared components for venue selection and tag filters.
+* Frontend: State management (query/mutations) for project/mission APIs, Vitest suites covering form logic and mission tagging.
+* Docs & tooling: Update architecture diagrams, entity relationships, and usage guides; extend guards or scripts if needed to enforce schema/spec alignment.
+
+## TESTS
+
+* Local: `pytest` (backend domain tests), `pnpm test --filter frontend` (mission/project UI), `tools/guards/run_all_guards.ps1`.
+* CI: Ensure `backend-tests.yml`, `frontend-tests.yml`, and `guards.yml` run successfully with coverage >=70% on backend domain modules touched.
+
+## CI
+
+* Reuse existing workflows; verify Alembic migrations execute in CI and seed data available for integration suites.
+* Monitor caches for pnpm and pip; no new secrets expected beyond existing database/SMTP placeholders.
+
+## ARCHIVE
+
+* After validation: update `docs/CHANGELOG.md`, `docs/codex/last_output.json`, and `docs/roadmap/ROADMAP.readme.md` history section.
+
+VALIDATE? no


### PR DESCRIPTION
Ref: docs/roadmap/step-02.md

* [x] Step file created/updated and ends with VALIDATE? yes/no
* [ ] Guards pass (roadmap_guard, docs_guard)
* [ ] Tests pass (backend, frontend) with coverage targets
* [ ] README indexes updated if needed
* [ ] CHANGELOG.md appended (append-only) with Ref line

## Summary
- Capture roadmap step 02 covering projects and reusable missions from the functional spec.

## Changes
- Add docs/roadmap/step-02.md with context, objectives, test strategy, and archive actions.
- Update docs/roadmap/ROADMAP.readme.md to point to the new current step and archive step 01.

## Testing
- Not run (documentation-only update).

## Risks
- Minimal: documentation misalignment if future implementation diverges from the described scope.

## Rollback
- Revert the step file and roadmap index update.


------
https://chatgpt.com/codex/tasks/task_e_68d3b697ed748330800b0eeb6a45990b