### PR TITLE
Align guards with roadmap sub-step format

### DIFF
--- a/docs/roadmap/ROADMAP.readme.md
+++ b/docs/roadmap/ROADMAP.readme.md
@@ -1,6 +1,7 @@
 # Roadmap
 
 ## Current Step
+- [STEP 02.01](./step-02.01.md)
 - [STEP 02](./step-02.md)
 
 ## History

--- a/docs/roadmap/step-02.01.md
+++ b/docs/roadmap/step-02.01.md
@@ -1,0 +1,36 @@
+# STEP 02.01 - Harmoniser les guards avec les sous-etapes
+
+## CONTEXT
+
+* La CI `guards` echoue car les scripts actuels ne reconnaissent pas les references `step-XX.YY` imposees par la nouvelle politique roadmap.
+* Les tests automatiques rejettent aussi la ligne finale enrichie `VALIDATE? no  (SAM ONLY may flip to yes)` et les titres `STEP XX.YY`.
+* Cette sous-etape cible uniquement la mise a jour des guards pour debloquer la suite de STEP 02.
+
+## OBJECTIVES
+
+* Supporter les references `docs/roadmap/step-XX.YY.md` dans les scripts `roadmap_guard` et `ensure_roadmap_ref`.
+* Accepter les titres et lignes finales conformes aux nouvelles directives dans `docs_guard`.
+* Documenter cette sous-etape et pointer la roadmap vers le fichier `step-02.01.md`.
+
+## CHANGES
+
+* Modifier `tools/guards/roadmap_guard.ps1` pour autoriser les sous-etapes et clarifier les messages d'erreur.
+* Mettre a jour `tools/guards/ensure_roadmap_ref.ps1` afin de detecter les references `step-XX.YY` dans commits, PR et ROADMAP.
+* Adapter `tools/guards/docs_guard.ps1` aux nouveaux formats de titres et de lignes `VALIDATE?`.
+* Creer `docs/roadmap/step-02.01.md` et ajuster `docs/roadmap/ROADMAP.readme.md` pour refleter la sous-etape active.
+
+## TESTS
+
+* Execution locale de `pwsh -File tools/guards/run_all_guards.ps1`.
+* Verifier que `roadmap_guard.ps1 -StepPath docs/roadmap/step-02.01.md` aboutit sans erreur.
+
+## CI
+
+* Workflow `guards.yml` attendu vert apres mise a jour.
+* Aucun nouveau secret requis; reutilisation des environnements existants.
+
+## ARCHIVE
+
+* Aucune mise a jour du `CHANGELOG` ou de `docs/codex/last_output.json` tant que la sous-etape n'est pas validee.
+
+VALIDATE? no  (SAM ONLY may flip to yes)

--- a/docs/roadmap/step-02.md
+++ b/docs/roadmap/step-02.md
@@ -34,4 +34,4 @@
 
 * After validation: update `docs/CHANGELOG.md`, `docs/codex/last_output.json`, and `docs/roadmap/ROADMAP.readme.md` history section.
 
-VALIDATE? no
+VALIDATE? no  (SAM ONLY may flip to yes)

--- a/tools/guards/docs_guard.ps1
+++ b/tools/guards/docs_guard.ps1
@@ -184,7 +184,7 @@ $requiredSections = @(
   '## CI',
   '## ARCHIVE'
 )
-$allowedFinalLines = @('VALIDATE? yes/no', 'VALIDATE? yes', 'VALIDATE? no')
+$finalLinePattern = '^VALIDATE\? (yes|no)(  \(SAM ONLY may flip to yes\))?$'
 
 foreach ($file in $roadmapFiles) {
   $content = Get-Content -Path $file.FullName
@@ -193,7 +193,7 @@ foreach ($file in $roadmapFiles) {
     exit 1
   }
   $raw = $content -join "`n"
-  if ($raw -notmatch '^# STEP [0-9]{2} - ') {
+  if ($raw -notmatch '^# STEP [0-9]{2}(?:\.[0-9]{2})? - ') {
     Write-Error "Le fichier $($file.Name) doit commencer par un titre '# STEP XX - ...'."
     exit 1
   }
@@ -209,8 +209,8 @@ foreach ($file in $roadmapFiles) {
     exit 1
   }
   $lastLine = $nonEmpty[-1]
-  if ($allowedFinalLines -notcontains $lastLine) {
-    Write-Error "La derniere ligne non vide de $($file.Name) doit etre l'une des valeurs 'VALIDATE? yes/no', 'VALIDATE? yes' ou 'VALIDATE? no'."
+  if (($lastLine -ne 'VALIDATE? yes/no') -and ($lastLine -notmatch $finalLinePattern)) {
+    Write-Error "La derniere ligne non vide de $($file.Name) doit suivre le format 'VALIDATE? yes/no' ou 'VALIDATE? yes|no  (SAM ONLY may flip to yes)'."
     exit 1
   }
   $linkPattern = "./$($file.Name)"

--- a/tools/guards/ensure_roadmap_ref.ps1
+++ b/tools/guards/ensure_roadmap_ref.ps1
@@ -12,7 +12,7 @@ function Write-Info {
   Write-Host "[ensure_roadmap_ref] $Message"
 }
 
-$refPattern = 'Ref: (docs/roadmap/step-[0-9]{2}\.md)'
+$refPattern = 'Ref: (docs/roadmap/step-[0-9]{2}(?:\.[0-9]{2})?\.md)'
 $gh = Get-Command gh -ErrorAction SilentlyContinue
 $commitMessage = ''
 $gitMessageLoaded = $false
@@ -92,16 +92,19 @@ function Get-PrContext {
 }
 
 function Resolve-StepPathFromRoadmap {
-$roadmapReadme = Join-Path 'docs' 'roadmap' 'ROADMAP.readme.md'
+  $roadmapReadme = Join-Path 'docs' 'roadmap' 'ROADMAP.readme.md'
   if (-not (Test-Path $roadmapReadme)) { return $null }
   try {
     $content = Get-Content $roadmapReadme -Raw
   } catch {
     return $null
   }
-  $match = [regex]::Match($content, 'step-([0-9]{2})\.md')
-  if ($match.Success -and $match.Value) {
-    return "docs/roadmap/$($match.Value)"
+  $matches = [regex]::Matches($content, 'step-([0-9]{2}(?:\.[0-9]{2})?)\.md')
+  if ($matches.Count -gt 0) {
+    $first = $matches[0].Value
+    if ($first) {
+      return "docs/roadmap/$first"
+    }
   }
   return $null
 }
@@ -146,8 +149,8 @@ if (-not $StepPath) {
 if ($StepPath) {
   $StepPath = $StepPath.Trim()
 }
-if ($StepPath -notmatch '^docs/roadmap/step-[0-9]{2}\.md$') {
-  throw "StepPath '$StepPath' is not in the expected format docs/roadmap/step-XX.md."
+if ($StepPath -notmatch '^docs/roadmap/step-[0-9]{2}(?:\.[0-9]{2})?\.md$') {
+  throw "StepPath '$StepPath' is not in the expected format docs/roadmap/step-XX[.YY].md."
 }
 
 $refLine = "Ref: $StepPath"

--- a/tools/guards/roadmap_guard.ps1
+++ b/tools/guards/roadmap_guard.ps1
@@ -12,7 +12,7 @@ function Write-Info {
   Write-Host "[roadmap_guard] $Message"
 }
 
-$refPattern = 'Ref: (docs/roadmap/step-[0-9]{2}\.md)'
+$refPattern = 'Ref: (docs/roadmap/step-[0-9]{2}(?:\.[0-9]{2})?\.md)'
 $gh = Get-Command gh -ErrorAction SilentlyContinue
 $commitMessage = ''
 $gitMessageLoaded = $false
@@ -112,8 +112,8 @@ if ($StepPath) {
   $StepPath = $StepPath.Trim()
 }
 
-if ($StepPath -notmatch '^docs/roadmap/step-[0-9]{2}\.md$') {
-  throw "StepPath '$StepPath' is not in the expected format docs/roadmap/step-XX.md."
+if ($StepPath -notmatch '^docs/roadmap/step-[0-9]{2}(?:\.[0-9]{2})?\.md$') {
+  throw "StepPath '$StepPath' is not in the expected format docs/roadmap/step-XX[.YY].md."
 }
 
 $scriptDir = Split-Path -Parent $MyInvocation.MyCommand.Path


### PR DESCRIPTION
Ref: docs/roadmap/step-02.01.md
STATE: awaiting-SAM

## Summary
- document the step-02.01 sub-step and list it as the active item in the roadmap index.
- update roadmap_guard, ensure_roadmap_ref, and docs_guard to accept step-XX.YY references and the extended VALIDATE line.

## Testing
- Not run (pwsh is unavailable in the execution environment).

STATE: awaiting-SAM

------
https://chatgpt.com/codex/tasks/task_e_68d3b854d57c8330ae7a94224f6b889d