### PR TITLE
docs: align roadmap files with guard expectations

### DIFF
--- a/docs/roadmap/ROADMAP.readme.md
+++ b/docs/roadmap/ROADMAP.readme.md
@@ -1,8 +1,26 @@
 # Roadmap
 
-## Current Step
-- [STEP 02.01](./step-02.01.md)
-- [STEP 02](./step-02.md)
+## SUMMARY
+- Iteration active : [STEP 02.01](./step-02.01.md) corrige les guards CI pour accepter les sous-etapes et le format `VALIDATE?` et desbloquer la progression.
+- Jalons en cours : [STEP 02](./step-02.md) etablit les fondations projets/missions selon la spec fonctionnelle v0.1 (modules 3.2 et 3.3).
+- Historique : [STEP 01](./step-01.md) a livre le socle auth multi-organisation et le RBAC initial.
 
-## History
-- [STEP 01](./step-01.md)
+## GOALS
+- Assurer la synchronisation entre roadmap, specification fonctionnelle et scripts de verification.
+- Donner une vue d'ensemble rapide des etapes actives et completes pour coordonner backend, frontend et devops.
+
+## CHANGES
+- Utiliser le gabarit commun (SUMMARY, GOALS, CHANGES, TESTS, CI, ARCHIVE) sur chaque fichier de roadmap, y compris `step-02.01.md` et `step-02.md`.
+- Maintenir des liens explicites vers `./step-02.01.md`, `./step-02.md` et `./step-01.md` pour suivre l'avancement.
+
+## TESTS
+- Executer `pwsh -File tools/guards/run_all_guards.ps1` avant commit pour verifier roadmap et documentation.
+- Surveiller `backend-tests.yml` et `frontend-tests.yml` pour valider les impacts techniques de chaque etape.
+
+## CI
+- Le workflow `guards.yml` doit rester vert pour chaque mise a jour de roadmap.
+- Les workflows `backend-tests.yml` et `frontend-tests.yml` couvrent respectivement les evolutions API et UI liees a STEP 02.
+
+## ARCHIVE
+- Deplacer les etapes finalisees dans la section historique tout en conservant leurs liens (`./step-01.md`).
+- Documenter la validation de chaque sous-etape directement dans le fichier correspondant (`./step-02.01.md`, `./step-02.md`).

--- a/docs/roadmap/step-02.01.md
+++ b/docs/roadmap/step-02.01.md
@@ -1,36 +1,30 @@
 # STEP 02.01 - Harmoniser les guards avec les sous-etapes
 
-## CONTEXT
+## SUMMARY
+- La CI `guards` echoue car les scripts actuels ne reconnaissent pas les references `step-XX.YY` imposees par la nouvelle politique roadmap.
+- Les tests automatiques rejettent la ligne finale `VALIDATE? no  (SAM ONLY may flip to yes)` et les titres `STEP XX.YY`, bloquant l'avancement de STEP 02.
+- Cette sous-etape cible uniquement la mise a jour des guards pour debloquer la suite de STEP 02.
 
-* La CI `guards` echoue car les scripts actuels ne reconnaissent pas les references `step-XX.YY` imposees par la nouvelle politique roadmap.
-* Les tests automatiques rejettent aussi la ligne finale enrichie `VALIDATE? no  (SAM ONLY may flip to yes)` et les titres `STEP XX.YY`.
-* Cette sous-etape cible uniquement la mise a jour des guards pour debloquer la suite de STEP 02.
-
-## OBJECTIVES
-
-* Supporter les references `docs/roadmap/step-XX.YY.md` dans les scripts `roadmap_guard` et `ensure_roadmap_ref`.
-* Accepter les titres et lignes finales conformes aux nouvelles directives dans `docs_guard`.
-* Documenter cette sous-etape et pointer la roadmap vers le fichier `step-02.01.md`.
+## GOALS
+- Supporter les references `docs/roadmap/step-XX.YY.md` dans les scripts `roadmap_guard` et `ensure_roadmap_ref`.
+- Accepter les titres et lignes finales conformes aux nouvelles directives dans `docs_guard`.
+- Documenter cette sous-etape et pointer la roadmap vers le fichier `step-02.01.md`.
 
 ## CHANGES
-
-* Modifier `tools/guards/roadmap_guard.ps1` pour autoriser les sous-etapes et clarifier les messages d'erreur.
-* Mettre a jour `tools/guards/ensure_roadmap_ref.ps1` afin de detecter les references `step-XX.YY` dans commits, PR et ROADMAP.
-* Adapter `tools/guards/docs_guard.ps1` aux nouveaux formats de titres et de lignes `VALIDATE?`.
-* Creer `docs/roadmap/step-02.01.md` et ajuster `docs/roadmap/ROADMAP.readme.md` pour refleter la sous-etape active.
+- Modifier `tools/guards/roadmap_guard.ps1` pour autoriser les sous-etapes et clarifier les messages d'erreur.
+- Mettre a jour `tools/guards/ensure_roadmap_ref.ps1` afin de detecter les references `step-XX.YY` dans commits, PR et ROADMAP.
+- Adapter `tools/guards/docs_guard.ps1` aux nouveaux formats de titres et de lignes `VALIDATE?`.
+- Creer `docs/roadmap/step-02.01.md` et ajuster `docs/roadmap/ROADMAP.readme.md` pour refleter la sous-etape active.
 
 ## TESTS
-
-* Execution locale de `pwsh -File tools/guards/run_all_guards.ps1`.
-* Verifier que `roadmap_guard.ps1 -StepPath docs/roadmap/step-02.01.md` aboutit sans erreur.
+- Execution locale de `pwsh -File tools/guards/run_all_guards.ps1`.
+- Verifier que `roadmap_guard.ps1 -StepPath docs/roadmap/step-02.01.md` aboutit sans erreur.
 
 ## CI
-
-* Workflow `guards.yml` attendu vert apres mise a jour.
-* Aucun nouveau secret requis; reutilisation des environnements existants.
+- Workflow `guards.yml` attendu vert apres mise a jour.
+- Aucun nouveau secret requis; reutilisation des environnements existants.
 
 ## ARCHIVE
-
-* Aucune mise a jour du `CHANGELOG` ou de `docs/codex/last_output.json` tant que la sous-etape n'est pas validee.
+- Aucune mise a jour du `CHANGELOG` ou de `docs/codex/last_output.json` tant que la sous-etape n'est pas validee.
 
 VALIDATE? no  (SAM ONLY may flip to yes)

--- a/docs/roadmap/step-02.md
+++ b/docs/roadmap/step-02.md
@@ -1,37 +1,31 @@
 # STEP 02 - Projects and missions foundations
 
-## CONTEXT
+## SUMMARY
+- Roadmap step alignee avec les modules 3.2 (Projects) et 3.3 (Missions reutilisables) de la spec pour couvrir WF-01 bout-en-bout.
+- Le socle Auth et RBAC de STEP 01 est disponible et permet de borner la propriete des projets et les permissions basees sur les roles.
+- La livraison anticipee debloque les entites partagees des sections 3.4, 3.6 et 3.7 (planning, disponibilites, paie) pour les iterations suivantes.
 
-* Roadmap step aligned with spec modules 3.2 (Projects) and 3.3 (Missions reutilisables) to enable WF-01 end-to-end planning.
-* Auth and RBAC baseline from step 01 is available, enabling scoped project ownership and role-based permissions.
-* Early delivery unlocks shared entities for planning, availability, and future payroll workflows defined in sections 3.4, 3.6, and 3.7.
-
-## OBJECTIVES
-
-* Implement backend domain for projects and reusable missions with persistence, validation, and RBAC-ready APIs.
-* Provide frontend management screens to create and maintain projects, associate venues, and catalogue mission templates.
-* Ensure workflows and data models satisfy WF-01 acceptance criteria on project setup and mission reuse.
+## GOALS
+- Implementer le domaine backend pour projets et missions reutilisables avec persistence, validation et APIs compatibles RBAC.
+- Fournir des interfaces frontend pour creer et maintenir les projets, associer les lieux et cataloguer les gabarits de mission.
+- Garantir que workflows et modeles de donnees satisfont les criteres d'acceptation WF-01 sur la mise en place des projets et missions reutilisables.
 
 ## CHANGES
-
-* Backend: SQLAlchemy models, Pydantic schemas, CRUD services, and FastAPI routers for Project, Venue linkage, Mission templates, and tags; Alembic migrations with constraints matching spec section 2.
-* Backend: RBAC policies covering project/mission scopes, unit and integration tests targeting >=70% coverage for the new domain, seed fixtures for WF-01 scenarios.
-* Frontend: React views for project list/detail and mission catalogue with forms, validation, and optimistic updates; shared components for venue selection and tag filters.
-* Frontend: State management (query/mutations) for project/mission APIs, Vitest suites covering form logic and mission tagging.
-* Docs & tooling: Update architecture diagrams, entity relationships, and usage guides; extend guards or scripts if needed to enforce schema/spec alignment.
+- Backend : SQLAlchemy models, schemas Pydantic, services CRUD et routes FastAPI pour Project, lien Venue, templates de mission et tags; migrations Alembic et contraintes spec section 2.
+- Backend : politiques RBAC couvrant les scopes projet/mission, tests unitaires et d'integration avec >=70 % de couverture pour le nouveau domaine, jeux de donnees WF-01.
+- Frontend : vues React pour la liste/detail projet et le catalogue de missions avec formulaires, validations et mises a jour optimistes; composants partages pour selection de lieu et filtres de tags.
+- Frontend : gestion d'etat (requete/mutations) pour les APIs projet/mission, suites Vitest couvrant la logique des formulaires et du tagging de mission.
+- Docs & tooling : mettre a jour les diagrammes d'architecture, relations d'entites et guides d'usage; etendre guards/scripts si necessaire pour imposer l'alignement schema/spec.
 
 ## TESTS
-
-* Local: `pytest` (backend domain tests), `pnpm test --filter frontend` (mission/project UI), `tools/guards/run_all_guards.ps1`.
-* CI: Ensure `backend-tests.yml`, `frontend-tests.yml`, and `guards.yml` run successfully with coverage >=70% on backend domain modules touched.
+- Local : `pytest` (domaines backend), `pnpm test --filter frontend` (UI missions/projets), `tools/guards/run_all_guards.ps1`.
+- CI : assurer l'execution reussie de `backend-tests.yml`, `frontend-tests.yml` et `guards.yml` avec couverture >=70 % sur le domaine backend touche.
 
 ## CI
-
-* Reuse existing workflows; verify Alembic migrations execute in CI and seed data available for integration suites.
-* Monitor caches for pnpm and pip; no new secrets expected beyond existing database/SMTP placeholders.
+- Reutiliser les workflows existants; verifier qu'Alembic s'execute en CI et que les donnees seeds sont disponibles pour les suites d'integration.
+- Surveiller les caches pnpm/pip; aucun nouveau secret attendu au-dela des placeholders base de donnees/SMTP.
 
 ## ARCHIVE
-
-* After validation: update `docs/CHANGELOG.md`, `docs/codex/last_output.json`, and `docs/roadmap/ROADMAP.readme.md` history section.
+- Apres validation : mettre a jour `docs/CHANGELOG.md`, `docs/codex/last_output.json` et la section historique de `docs/roadmap/ROADMAP.readme.md`.
 
 VALIDATE? no  (SAM ONLY may flip to yes)


### PR DESCRIPTION
## Summary
- align the roadmap overview and active steps with the guard-mandated template
- ensure sub-step STEP 02.01 follows SUMMARY/GOALS headings expected by CI guards

## Changes
- rewrite `docs/roadmap/ROADMAP.readme.md` with SUMMARY/GOALS/CHANGES/TESTS/CI/ARCHIVE sections and explicit step links
- rename the context/objective sections in `docs/roadmap/step-02.md` and `docs/roadmap/step-02.01.md` to the required headings while keeping existing details

## Testing
- `pwsh -File tools/guards/run_all_guards.ps1` *(fails: `pwsh` is not installed in the execution environment)*

## Risk
- Low: documentation-only updates to match guard expectations.

## Rollback
- Revert this commit to restore the previous roadmap wording.

## Roadmap Ref
- docs/roadmap/step-02.01.md

## Checklist
- [x] Documentation updated
- [ ] New tests added
- [ ] Requires new secrets


------
https://chatgpt.com/codex/tasks/task_e_68d3ba525fa483308a9f170b6b11fd06