### PR TITLE
chore(step-02): add venue tests and open frontend sub-step

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -8,3 +8,7 @@
 
 ## 2025-09-26
 - Livraison du domaine backend projets/missions (models SQLAlchemy, APIs FastAPI, RBAC et tests Pytest 79.74 %) couvrant venues, tags et gabarits reutilisables. Ref: docs/roadmap/step-02.md
+
+## 2025-09-27
+- Renforcement des tests Pytest sur les lieux (CRUD, conflits, permissions) via `tests/backend/test_venues.py` pour consolider STEP 02. Ref: docs/roadmap/step-02.md
+- Ouverture de la sous-etape frontend projets/missions [STEP 02.02](./roadmap/step-02.02.md) afin de planifier la livraison UI et la toolchain React. Ref: docs/roadmap/step-02.02.md

--- a/docs/codex/last_output.json
+++ b/docs/codex/last_output.json
@@ -1,15 +1,15 @@
 {
-  "timestamp": "2025-09-26T10:00:00Z",
+  "timestamp": "2025-09-27T09:30:00Z",
   "plan": [
-    "Stabiliser le backend projets/missions (tests Pytest 79.7 %) et orchestrer l'exposition RBAC aux autres modules WF-01.",
-    "Livrer les vues frontend (React/Vite) pour projets et gabarits de missions avec couverture Vitest et états optimistes.",
-    "Mettre à jour la documentation (diagrammes, guides RBAC, roadmap) et synchroniser les guards docs/roadmap."
+    "Finaliser la montee en couverture backend (venues) et stabiliser le RBAC avant d'exposer le frontend.",
+    "Piloter la sous-etape STEP 02.02 pour livrer les vues React projets/missions (pnpm, Vitest, React Query).",
+    "Mettre a jour la documentation (roadmap, changelog) et preparer les guards UI/documentation associes."
   ],
-  "last_update": "2025-09-26T10:00:00Z",
+  "last_update": "2025-09-27T09:30:00Z",
   "status": "in_progress",
   "notes": [
-    "Les APIs projets/missions (venues, tags, templates) sont en production avec RBAC Owner/Admin manage, Member/Viewer view.",
-    "Pytest couvre le domaine à 79.74 %; rester vigilant sur les routes venues pour ajouter des tests supplémentaires si nécessaire.",
-    "Prochain focus: frontend mission/project catalog + mise à jour des guards/documentation pour STEP 02."
+    "Les tests Pytest incluent desormais `tests/backend/test_venues.py` couvrant CRUD, conflits et droits Viewer/Admin.",
+    "La sous-etape STEP 02.02 est ouverte pour cadrer l'implementation frontend (React + toolchain pnpm).",
+    "Prochain focus: initialiser la base frontend, configurer pnpm et ecrire les premiers tests Vitest." 
   ]
 }

--- a/docs/roadmap/ROADMAP.readme.md
+++ b/docs/roadmap/ROADMAP.readme.md
@@ -2,6 +2,7 @@
 
 ## SUMMARY
 - Iteration active : [STEP 02](./step-02.md) livre le domaine backend projets/missions (RBAC, CRUD, tests) et prepare les travaux frontend.
+- Sous-etape en cours : [STEP 02.02](./step-02.02.md) organise la livraison des vues React projets/missions et la toolchain frontend.
 - Jalons a suivre : completion frontend/UX missions-projets et mise a jour documentaire/guards pour STEP 02.
 - Historique : [STEP 02.01](./step-02.01.md) a aligne les guards CI sur le format roadmap; [STEP 01](./step-01.md) a livre le socle auth multi-organisation et le RBAC initial.
 

--- a/docs/roadmap/step-02.02.md
+++ b/docs/roadmap/step-02.02.md
@@ -1,0 +1,32 @@
+# STEP 02.02 - Interfaces frontend projets et missions
+
+## SUMMARY
+- Sous-etape ouverte pour couvrir la partie UI/UX de STEP 02 en livrant les ecrans React listes/détails projet et catalogue des gabarits.
+- Viser une integration avec les APIs backend existantes (projects, venues, mission-templates, mission-tags) via React Query.
+- Mettre en place la charte UI (shadcn/Tailwind) et les tests Vitest correspondant.
+
+## GOALS
+- Livrer les pages React Projet (liste + detail) et Mission Templates avec appels API et gestion des etats de chargement/erreurs.
+- Ajouter un store ou React Query pour synchroniser les donnees et fournir des mutations optimistes sur create/update/delete.
+- Couvrir les composants et hooks critiques par Vitest/Testing Library avec seuil de couverture >=70% sur le scope frontend.
+
+## CHANGES
+- Initialiser la base frontend (`src/frontend`) avec Vite + TypeScript + Tailwind/shadcn et configurer pnpm.
+- Implementer les hooks/API clients pour projects, venues, mission tags et templates avec gestion d'erreurs centralisee.
+- Creer les composants UI (tables, formulaires, modals) et routage correspondant, en assurant l'accessibilite clavier.
+- Ajouter suites Vitest et configurations lint/format specifiques au frontend.
+
+## TESTS
+- `pnpm install` puis `pnpm test -- --runInBand` pour la couverture frontend.
+- `pnpm lint` et `pnpm format:check` pour garantir la qualite de code.
+- Conserver `pytest` pour s'assurer que les APIs backend restent stables durant l'integration.
+
+## CI
+- Etendre `frontend-tests.yml` pour inclure lint, build et Vitest.
+- Ajuster `guards.yml` si de nouvelles regles documentaires/front sont necessaires (captures, storybook, etc.).
+
+## ARCHIVE
+- A cloturer: capture(s) UI dans la documentation, mise a jour du changelog et des diagrammes lorsque les vues seront live.
+- Synchroniser `docs/codex/last_output.json` et `docs/roadmap/ROADMAP.readme.md` lorsque la sous-etape sera validee.
+
+VALIDATE? no  (SAM ONLY may flip to yes)

--- a/docs/roadmap/step-02.md
+++ b/docs/roadmap/step-02.md
@@ -17,6 +17,7 @@
 ## RESULTATS
 - Les endpoints projets/missions retournent des reponses structurees (camelCase) avec venues et tags embarques; couverture Pytest 79.74 % (> 70 % cible backend).
 - Les permissions Owner/Admin gerent, Member/Viewer consultent; les erreurs de references (venue/tag inconnus) sont renvoyees en 404.
+- Suite au renforcement des tests (`tests/backend/test_venues.py`), le module venues est couvert sur les cycles CRUD et RBAC avec verification des conflits de nom et des droits Viewer.
 - Frontend, guards graphiques et documentation visuelle restent a implementer pour finaliser la step.
 
 ## PROCHAINES ETAPES

--- a/tests/backend/test_venues.py
+++ b/tests/backend/test_venues.py
@@ -1,0 +1,186 @@
+from __future__ import annotations
+
+from fastapi.testclient import TestClient
+import pytest
+
+from backend.config import Settings
+from backend.main import create_app
+from backend.rbac import Role
+
+
+@pytest.fixture()
+def app() -> TestClient:
+    settings = Settings(database_url="sqlite+pysqlite:///:memory:")
+    application = create_app(settings=settings)
+    with TestClient(application) as client:
+        yield client
+
+
+def _register(
+    client: TestClient,
+    *,
+    email: str,
+    password: str,
+    organization_name: str,
+    organization_slug: str,
+) -> dict[str, str]:
+    response = client.post(
+        "/api/v1/auth/register",
+        json={
+            "email": email,
+            "password": password,
+            "organizationName": organization_name,
+            "organizationSlug": organization_slug,
+        },
+    )
+    assert response.status_code == 201, response.text
+    return response.json()
+
+
+def test_venue_crud_cycle(app: TestClient) -> None:
+    owner = _register(
+        app,
+        email="owner@example.com",
+        password="Password123!",
+        organization_name="Orbit",
+        organization_slug="orbit",
+    )
+
+    create_response = app.post(
+        "/api/v1/venues",
+        headers={"X-Session-Token": owner["sessionToken"]},
+        json={"name": "  Studio Nova  ", "city": "Lyon"},
+    )
+    assert create_response.status_code == 201, create_response.text
+    venue = create_response.json()
+    assert venue["name"] == "Studio Nova"
+    assert venue["city"] == "Lyon"
+
+    detail_response = app.get(
+        f"/api/v1/venues/{venue['id']}",
+        headers={"X-Session-Token": owner["sessionToken"]},
+    )
+    assert detail_response.status_code == 200
+    detail = detail_response.json()
+    assert detail["id"] == venue["id"]
+
+    update_response = app.put(
+        f"/api/v1/venues/{venue['id']}",
+        headers={"X-Session-Token": owner["sessionToken"]},
+        json={"name": "Grande Salle", "country": "France", "capacity": 900},
+    )
+    assert update_response.status_code == 200, update_response.text
+    updated = update_response.json()
+    assert updated["name"] == "Grande Salle"
+    assert updated["country"] == "France"
+    assert updated["capacity"] == 900
+
+    list_response = app.get(
+        "/api/v1/venues",
+        headers={"X-Session-Token": owner["sessionToken"]},
+    )
+    assert list_response.status_code == 200
+    venues = list_response.json()
+    assert len(venues) == 1
+    assert venues[0]["id"] == venue["id"]
+
+    delete_response = app.delete(
+        f"/api/v1/venues/{venue['id']}",
+        headers={"X-Session-Token": owner["sessionToken"]},
+    )
+    assert delete_response.status_code == 204
+
+    empty_response = app.get(
+        "/api/v1/venues",
+        headers={"X-Session-Token": owner["sessionToken"]},
+    )
+    assert empty_response.status_code == 200
+    assert empty_response.json() == []
+
+
+def test_duplicate_name_conflict_and_cross_org_allowed(app: TestClient) -> None:
+    owner_one = _register(
+        app,
+        email="alpha@example.com",
+        password="Password123!",
+        organization_name="Alpha Co",
+        organization_slug="alpha",
+    )
+
+    owner_two = _register(
+        app,
+        email="beta@example.com",
+        password="Password123!",
+        organization_name="Beta Co",
+        organization_slug="beta",
+    )
+
+    first = app.post(
+        "/api/v1/venues",
+        headers={"X-Session-Token": owner_one["sessionToken"]},
+        json={"name": "Le Cube"},
+    )
+    assert first.status_code == 201
+
+    conflict = app.post(
+        "/api/v1/venues",
+        headers={"X-Session-Token": owner_one["sessionToken"]},
+        json={"name": "Le Cube"},
+    )
+    assert conflict.status_code == 409
+
+    other_org = app.post(
+        "/api/v1/venues",
+        headers={"X-Session-Token": owner_two["sessionToken"]},
+        json={"name": "Le Cube"},
+    )
+    assert other_org.status_code == 201
+
+
+def test_viewer_permissions_on_venues(app: TestClient) -> None:
+    owner = _register(
+        app,
+        email="lead@example.com",
+        password="Password123!",
+        organization_name="Gamma",
+        organization_slug="gamma",
+    )
+
+    invitation = app.post(
+        "/api/v1/auth/invitations",
+        headers={"X-Session-Token": owner["sessionToken"]},
+        json={"email": "viewer@example.com", "role": Role.VIEWER.value},
+    )
+    assert invitation.status_code == 201
+    token = invitation.json()["token"]
+
+    acceptance = app.post(
+        "/api/v1/auth/invitations/accept",
+        json={
+            "token": token,
+            "email": "viewer@example.com",
+            "password": "ViewerPass123!",
+        },
+    )
+    assert acceptance.status_code == 200
+
+    login = app.post(
+        "/api/v1/auth/login",
+        json={"email": "viewer@example.com", "password": "ViewerPass123!"},
+    )
+    assert login.status_code == 200
+    viewer_session = login.json()["sessionToken"]
+
+    forbidden = app.post(
+        "/api/v1/venues",
+        headers={"X-Session-Token": viewer_session},
+        json={"name": "Lieu secret"},
+    )
+    assert forbidden.status_code == 403
+
+    allowed = app.get(
+        "/api/v1/venues",
+        headers={"X-Session-Token": viewer_session},
+    )
+    assert allowed.status_code == 200
+    assert allowed.json() == []


### PR DESCRIPTION
## Summary
- add backend integration tests covering venue CRUD, duplicates and viewer permissions
- document the new coverage in step-02 and changelog, and open sub-step 02.02 for the frontend delivery plan
- refresh codex execution log with the updated plan

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68d524c85f3083309ab022643b619681