### PR TITLE
Fix frontend test runner compatibility with runInBand flag

### DIFF
--- a/src/frontend/package.json
+++ b/src/frontend/package.json
@@ -7,7 +7,7 @@
     "dev": "vite",
     "build": "tsc && vite build",
     "preview": "vite preview",
-    "test": "vitest",
+    "test": "node ./scripts/run-vitest.mjs",
     "test:coverage": "vitest run --coverage",
     "lint": "eslint \"src/**/*.{ts,tsx}\"",
     "format": "prettier --write .",

--- a/src/frontend/scripts/run-vitest.mjs
+++ b/src/frontend/scripts/run-vitest.mjs
@@ -1,0 +1,40 @@
+#!/usr/bin/env node
+import { spawn } from 'node:child_process';
+
+const rawArgs = process.argv.slice(2);
+const filteredArgs = [];
+let runInBandRequested = false;
+
+for (const arg of rawArgs) {
+  if (arg === '--runInBand' || arg === '--run-in-band') {
+    runInBandRequested = true;
+    continue;
+  }
+  filteredArgs.push(arg);
+}
+
+const vitestArgs = [...filteredArgs];
+
+if (runInBandRequested) {
+  const firstArg = vitestArgs[0];
+  const hasExplicitCommand = Boolean(firstArg && !firstArg.startsWith('-'));
+
+  if (!hasExplicitCommand) {
+    vitestArgs.unshift('run');
+  }
+
+  vitestArgs.push('--pool=threads', '--maxWorkers=1', '--minWorkers=1', '--no-file-parallelism');
+}
+
+const child = spawn('vitest', vitestArgs, {
+  stdio: 'inherit',
+  shell: process.platform === 'win32',
+});
+
+child.on('exit', (code, signal) => {
+  if (signal) {
+    process.kill(process.pid, signal);
+    return;
+  }
+  process.exit(code ?? 0);
+});


### PR DESCRIPTION
## Summary
- add a Node wrapper that converts the --runInBand flag into sequential Vitest options
- update the frontend test script to invoke the wrapper so CI can forward Jest-style flags

## Testing
- pnpm frontend:test -- --runInBand


------
https://chatgpt.com/codex/tasks/task_e_68d52f4ec3248330992f87c87796f080