### PR TITLE
fix: expose pnpm binary in CI workflows

### DIFF
--- a/.github/workflows/frontend-tests.yml
+++ b/.github/workflows/frontend-tests.yml
@@ -53,20 +53,17 @@ jobs:
         uses: actions/setup-node@v4
         with:
           node-version: 20
-      - name: Install pnpm
-        run: npm install -g pnpm
+      - name: Configure pnpm home
+        if: ${{ steps.detect_pnpm.outputs.has-pnpm == 'true' }}
+        run: |
+          echo "PNPM_HOME=$HOME/.local/share/pnpm" >> "$GITHUB_ENV"
+          echo "$HOME/.local/share/pnpm" >> "$GITHUB_PATH"
       - name: Set up pnpm
         if: ${{ steps.detect_pnpm.outputs.has-pnpm == 'true' }}
         uses: pnpm/action-setup@v4
         with:
           version: ${{ env.PNPM_VERSION }}
           run_install: false
-      - name: Enable corepack
-        if: ${{ steps.detect_pnpm.outputs.has-pnpm == 'true' }}
-        run: corepack enable
-      - name: Prepare pnpm via corepack
-        if: ${{ steps.detect_pnpm.outputs.has-pnpm == 'true' }}
-        run: corepack prepare pnpm@${{ env.PNPM_VERSION }} --activate
       - name: Show pnpm version
         if: ${{ steps.detect_pnpm.outputs.has-pnpm == 'true' }}
         run: pnpm --version

--- a/.github/workflows/guards.yml
+++ b/.github/workflows/guards.yml
@@ -53,18 +53,17 @@ jobs:
         uses: actions/setup-node@v4
         with:
           node-version: 20
+      - name: Configure pnpm home
+        if: ${{ steps.detect_pnpm.outputs.has-pnpm == 'true' }}
+        run: |
+          echo "PNPM_HOME=$HOME/.local/share/pnpm" >> "$GITHUB_ENV"
+          echo "$HOME/.local/share/pnpm" >> "$GITHUB_PATH"
       - name: Set up pnpm
         if: ${{ steps.detect_pnpm.outputs.has-pnpm == 'true' }}
         uses: pnpm/action-setup@v4
         with:
           version: ${{ env.PNPM_VERSION }}
           run_install: false
-      - name: Enable corepack
-        if: ${{ steps.detect_pnpm.outputs.has-pnpm == 'true' }}
-        run: corepack enable
-      - name: Prepare pnpm via corepack
-        if: ${{ steps.detect_pnpm.outputs.has-pnpm == 'true' }}
-        run: corepack prepare pnpm@${{ env.PNPM_VERSION }} --activate
       - name: Show pnpm version
         if: ${{ steps.detect_pnpm.outputs.has-pnpm == 'true' }}
         run: pnpm --version


### PR DESCRIPTION
Ref: docs/roadmap/step-02.02.md

## Summary
- ensure pnpm gets added to the PATH before workflow steps that call it

## Changes
- export PNPM_HOME and append it to PATH in the frontend and guards pipelines before pnpm/action-setup runs

## Testing
- `pwsh -File tools/guards/run_all_guards.ps1` *(fails: pwsh is not available in the container image)*

## Checklist
* [ ] Spec ajoutee/maj: docs/specs/spec-fonctionnelle-v0.1.md
* [ ] Agents referencent la SUT (SUT: docs/specs/spec-fonctionnelle-v0.1.md)
* [ ] Guards OK (docs_guard, roadmap_guard)
* [ ] Tests et lint OK

------
https://chatgpt.com/codex/tasks/task_e_68d53185f52c83309cf0ec5a21d8a618