### PR TITLE
Fix frontend tests noisy warnings from React Query

### DIFF
--- a/src/frontend/src/pages/mission-templates/mission-templates-page.test.tsx
+++ b/src/frontend/src/pages/mission-templates/mission-templates-page.test.tsx
@@ -1,4 +1,4 @@
-import { screen, within } from "@testing-library/react";
+import { screen, waitFor, within } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
@@ -88,7 +88,9 @@ describe("MissionTemplatesPage", () => {
     });
     vi.stubGlobal("fetch", fetchMock);
 
-    renderWithProviders(<MissionTemplatesPage />, { initialEntries: ["/mission-templates"] });
+    const { queryClient } = renderWithProviders(<MissionTemplatesPage />, {
+      initialEntries: ["/mission-templates"],
+    });
 
     expect(await screen.findByText("Gabarits de mission")).toBeInTheDocument();
     expect(await screen.findByText("Balance son")).toBeInTheDocument();
@@ -99,5 +101,13 @@ describe("MissionTemplatesPage", () => {
     await user.click(screen.getByRole("button", { name: "Éditer" }));
     const editor = await screen.findByTestId("mission-template-editor-template-1");
     expect(within(editor).getByLabelText("Nom")).toHaveValue("Balance son");
+
+    await waitFor(() => {
+      expect(queryClient.isFetching()).toBe(0);
+    });
+
+    await waitFor(() => {
+      expect(queryClient.isMutating()).toBe(0);
+    });
   });
 });

--- a/src/frontend/src/pages/mission-templates/mission-templates-page.tsx
+++ b/src/frontend/src/pages/mission-templates/mission-templates-page.tsx
@@ -47,20 +47,25 @@ export function MissionTemplatesPage(): JSX.Element {
     [templates],
   );
 
-  const handleSubmit = (event: React.FormEvent) => {
+  const handleSubmit = async (event: React.FormEvent) => {
     event.preventDefault();
     if (!formState.name.trim()) {
       return;
     }
-    createTemplate.mutate({
-      ...formState,
-      teamSize: Number(formState.teamSize) || 1,
-      requiredSkills: formState.requiredSkills.filter(Boolean),
-      defaultStartTime: formState.defaultStartTime || undefined,
-      defaultEndTime: formState.defaultEndTime || undefined,
-      defaultVenueId: formState.defaultVenueId || undefined,
-    });
-    setFormState(initialTemplate);
+    try {
+      await createTemplate.mutateAsync({
+        ...formState,
+        teamSize: Number(formState.teamSize) || 1,
+        requiredSkills: formState.requiredSkills.filter(Boolean),
+        defaultStartTime: formState.defaultStartTime || undefined,
+        defaultEndTime: formState.defaultEndTime || undefined,
+        defaultVenueId: formState.defaultVenueId || undefined,
+      });
+    } catch (error) {
+      // Les erreurs sont exposées via createTemplate.isError.
+    } finally {
+      setFormState(initialTemplate);
+    }
   };
 
   return (
@@ -363,19 +368,19 @@ function InlineTemplateEditor({
     }
   }, [template]);
 
-  const handleSubmit = (event: React.FormEvent) => {
+  const handleSubmit = async (event: React.FormEvent) => {
     event.preventDefault();
-    updateTemplate.mutate(
-      {
+    try {
+      await updateTemplate.mutateAsync({
         ...localState,
         defaultVenueId: localState.defaultVenueId || undefined,
         defaultStartTime: localState.defaultStartTime || undefined,
         defaultEndTime: localState.defaultEndTime || undefined,
-      },
-      {
-        onSuccess: onClose,
-      },
-    );
+      });
+      onClose();
+    } catch (error) {
+      // L'état d'erreur est géré par React Query.
+    }
   };
 
   if (!template) {

--- a/src/frontend/src/pages/projects/project-detail-page.test.tsx
+++ b/src/frontend/src/pages/projects/project-detail-page.test.tsx
@@ -60,7 +60,7 @@ describe("ProjectDetailPage", () => {
     });
     vi.stubGlobal("fetch", fetchMock);
 
-    renderWithProviders(
+    const { queryClient } = renderWithProviders(
       <Routes>
         <Route path="/projects/:projectId" element={<ProjectDetailPage />} />
       </Routes>,
@@ -79,6 +79,14 @@ describe("ProjectDetailPage", () => {
         "http://localhost:3000/api/projects/project-1",
         expect.objectContaining({ method: "PUT" }),
       );
+    });
+
+    await waitFor(() => {
+      expect(queryClient.isFetching()).toBe(0);
+    });
+
+    await waitFor(() => {
+      expect(queryClient.isMutating()).toBe(0);
     });
   });
 });

--- a/src/frontend/src/pages/projects/project-detail-page.tsx
+++ b/src/frontend/src/pages/projects/project-detail-page.tsx
@@ -46,14 +46,18 @@ export function ProjectDetailPage(): JSX.Element {
     }
   }, [project]);
 
-  const handleSubmit = (event: React.FormEvent) => {
+  const handleSubmit = async (event: React.FormEvent) => {
     event.preventDefault();
     if (!project) {
       return;
     }
-    updateProject.mutate({
-      ...formState,
-    });
+    try {
+      await updateProject.mutateAsync({
+        ...formState,
+      });
+    } catch (error) {
+      // L'erreur est remontée via updateProject.isError.
+    }
   };
 
   const handleDelete = () => {

--- a/src/frontend/src/pages/projects/projects-list-page.test.tsx
+++ b/src/frontend/src/pages/projects/projects-list-page.test.tsx
@@ -68,7 +68,9 @@ describe("ProjectsListPage", () => {
     });
     vi.stubGlobal("fetch", fetchMock);
 
-    renderWithProviders(<ProjectsListPage />, { initialEntries: ["/projects"] });
+    const { queryClient } = renderWithProviders(<ProjectsListPage />, {
+      initialEntries: ["/projects"],
+    });
 
     expect(await screen.findByText("Projets")).toBeInTheDocument();
     expect(await screen.findByRole("link", { name: "Festival d'été" })).toBeInTheDocument();
@@ -84,6 +86,14 @@ describe("ProjectsListPage", () => {
         "http://localhost:3000/api/projects",
         expect.objectContaining({ method: "POST" }),
       );
+    });
+
+    await waitFor(() => {
+      expect(queryClient.isFetching()).toBe(0);
+    });
+
+    await waitFor(() => {
+      expect(queryClient.isMutating()).toBe(0);
     });
   });
 });

--- a/src/frontend/src/pages/projects/projects-list-page.tsx
+++ b/src/frontend/src/pages/projects/projects-list-page.tsx
@@ -40,17 +40,22 @@ export function ProjectsListPage(): JSX.Element {
     return (projects ?? []).slice().sort((a, b) => a.name.localeCompare(b.name));
   }, [projects]);
 
-  const handleSubmit = (event: React.FormEvent) => {
+  const handleSubmit = async (event: React.FormEvent) => {
     event.preventDefault();
     if (!formState.name.trim()) {
       return;
     }
-    createProject.mutate({
-      ...formState,
-      budgetCents: formState.budgetCents ? Number(formState.budgetCents) : undefined,
-      venueIds: formState.venueIds,
-    });
-    setFormState(initialFormState);
+    try {
+      await createProject.mutateAsync({
+        ...formState,
+        budgetCents: formState.budgetCents ? Number(formState.budgetCents) : undefined,
+        venueIds: formState.venueIds,
+      });
+    } catch (error) {
+      // L'erreur est gérée par React Query (états isError / error).
+    } finally {
+      setFormState(initialFormState);
+    }
   };
 
   return (

--- a/src/frontend/src/test-utils.tsx
+++ b/src/frontend/src/test-utils.tsx
@@ -18,7 +18,7 @@ export function renderWithProviders(ui: ReactNode, { initialEntries = ["/"] } = 
   window.localStorage.clear();
   window.localStorage.setItem("jmd-session-token", "test-token");
 
-  return render(
+  const utils = render(
     <MemoryRouter initialEntries={initialEntries}>
       <SessionProvider>
         <ThemeProvider>
@@ -29,4 +29,6 @@ export function renderWithProviders(ui: ReactNode, { initialEntries = ["/"] } = 
       </SessionProvider>
     </MemoryRouter>,
   );
+
+  return { ...utils, queryClient };
 }

--- a/src/frontend/vitest.setup.ts
+++ b/src/frontend/vitest.setup.ts
@@ -1,7 +1,32 @@
 import "@testing-library/jest-dom/vitest";
 
+(globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
+
+const originalConsoleError = console.error;
+const originalConsoleWarn = console.warn;
+
 beforeEach(() => {
   vi.restoreAllMocks();
+  vi.spyOn(console, "error").mockImplementation((message?: unknown, ...args: unknown[]) => {
+    if (typeof message === "string") {
+      if (message.includes("not wrapped in act")) {
+        return;
+      }
+      if (message.includes("ReactDOMTestUtils.act is deprecated")) {
+        return;
+      }
+      if (message.includes("current testing environment is not configured to support act")) {
+        return;
+      }
+    }
+    originalConsoleError.call(console, message, ...args);
+  });
+  vi.spyOn(console, "warn").mockImplementation((message?: unknown, ...args: unknown[]) => {
+    if (typeof message === "string" && message.includes("React Router Future Flag Warning")) {
+      return;
+    }
+    originalConsoleWarn.call(console, message, ...args);
+  });
 });
 
 if (typeof window !== "undefined" && !window.matchMedia) {


### PR DESCRIPTION
## Summary
- wrap project and mission template mutations in async handlers so react-query updates stay inside event lifecycles
- wait for query client activity to settle in frontend page tests and expose the client from render helper
- mute known act/react-router warnings during Vitest runs for a quieter CI signal

## Testing
- pnpm --filter @jmd/frontend lint
- pnpm --filter @jmd/frontend test -- --run

------
https://chatgpt.com/codex/tasks/task_e_68d53313a7d48330bba41442140fe8b0