### PR TITLE
Fix pnpm installation in CI workflows

### DIFF
--- a/.github/workflows/frontend-tests.yml
+++ b/.github/workflows/frontend-tests.yml
@@ -53,6 +53,12 @@ jobs:
         uses: actions/setup-node@v4
         with:
           node-version: 20
+      - name: Enable Corepack
+        if: ${{ steps.detect_pnpm.outputs.has-pnpm == 'true' }}
+        run: corepack enable
+      - name: Prepare pnpm
+        if: ${{ steps.detect_pnpm.outputs.has-pnpm == 'true' }}
+        run: corepack prepare pnpm@${{ env.PNPM_VERSION }} --activate
       - name: Configure pnpm home
         if: ${{ steps.detect_pnpm.outputs.has-pnpm == 'true' }}
         run: |

--- a/.github/workflows/guards.yml
+++ b/.github/workflows/guards.yml
@@ -53,6 +53,12 @@ jobs:
         uses: actions/setup-node@v4
         with:
           node-version: 20
+      - name: Enable Corepack
+        if: ${{ steps.detect_pnpm.outputs.has-pnpm == 'true' }}
+        run: corepack enable
+      - name: Prepare pnpm
+        if: ${{ steps.detect_pnpm.outputs.has-pnpm == 'true' }}
+        run: corepack prepare pnpm@${{ env.PNPM_VERSION }} --activate
       - name: Configure pnpm home
         if: ${{ steps.detect_pnpm.outputs.has-pnpm == 'true' }}
         run: |


### PR DESCRIPTION
Ref: docs/roadmap/step-02.02.md

## Summary
- ensure pnpm is provisioned before running cached installs in CI

## Changes
- enable corepack and activate the requested pnpm version in frontend and guard workflows

## Testing
- `pwsh -File tools/guards/run_all_guards.ps1` *(fails: `pwsh` not available in container)*

## Checklist
* [ ] Spec ajoutee/maj: docs/specs/spec-fonctionnelle-v0.1.md
* [ ] Agents referencent la SUT (SUT: docs/specs/spec-fonctionnelle-v0.1.md)
* [ ] Guards OK (docs_guard, roadmap_guard)
* [ ] Tests et lint OK

------
https://chatgpt.com/codex/tasks/task_e_68d535958e6883308f83ebbe8e2f1391