### PR TITLE
chore: route frontend scripts through corepack

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,12 +3,12 @@
   "private": true,
   "packageManager": "pnpm@8.15.0",
   "scripts": {
-    "frontend:dev": "pnpm --filter @jmd/frontend dev",
-    "frontend:build": "pnpm --filter @jmd/frontend build",
-    "frontend:test": "pnpm --filter @jmd/frontend test",
-    "frontend:lint": "pnpm --filter @jmd/frontend lint",
-    "frontend:format": "pnpm --filter @jmd/frontend format",
-    "frontend:format:check": "pnpm --filter @jmd/frontend format:check",
-    "frontend:typecheck": "pnpm --filter @jmd/frontend typecheck"
+    "frontend:dev": "corepack pnpm --filter @jmd/frontend dev",
+    "frontend:build": "corepack pnpm --filter @jmd/frontend build",
+    "frontend:test": "corepack pnpm --filter @jmd/frontend test",
+    "frontend:lint": "corepack pnpm --filter @jmd/frontend lint",
+    "frontend:format": "corepack pnpm --filter @jmd/frontend format",
+    "frontend:format:check": "corepack pnpm --filter @jmd/frontend format:check",
+    "frontend:typecheck": "corepack pnpm --filter @jmd/frontend typecheck"
   }
 }


### PR DESCRIPTION
Ref: docs/roadmap/step-02.02.md

## Summary
- ensure monorepo npm scripts invoke pnpm through Corepack

## Changes
- update frontend script entries in package.json to call `corepack pnpm`

## Testing
- npm run frontend:lint
- npm run frontend:test -- -- --run

## Checklist
* [x] Tests et lint OK


------
https://chatgpt.com/codex/tasks/task_e_68d57aac715c8330b0454edb029bb3eb