### PR TITLE
Fix pnpm setup order in CI workflows

### DIFF
--- a/.github/workflows/frontend-tests.yml
+++ b/.github/workflows/frontend-tests.yml
@@ -41,6 +41,17 @@ jobs:
           "has-pnpm=$hasValue" | Out-File -FilePath $env:GITHUB_OUTPUT -Encoding utf8 -Append
           "project-dir=$projectDir" | Out-File -FilePath $env:GITHUB_OUTPUT -Encoding utf8 -Append
           "lock-path=$lockPath" | Out-File -FilePath $env:GITHUB_OUTPUT -Encoding utf8 -Append
+      - name: Configure pnpm home
+        if: ${{ steps.detect_pnpm.outputs.has-pnpm == 'true' }}
+        run: |
+          echo "PNPM_HOME=$HOME/.local/share/pnpm" >> "$GITHUB_ENV"
+          echo "$HOME/.local/share/pnpm" >> "$GITHUB_PATH"
+      - name: Install pnpm
+        if: ${{ steps.detect_pnpm.outputs.has-pnpm == 'true' }}
+        uses: pnpm/action-setup@v4
+        with:
+          version: ${{ env.PNPM_VERSION }}
+          run_install: false
       - name: Setup Node
         if: ${{ steps.detect_pnpm.outputs.has-pnpm == 'true' }}
         uses: actions/setup-node@v4
@@ -59,17 +70,6 @@ jobs:
       - name: Prepare pnpm
         if: ${{ steps.detect_pnpm.outputs.has-pnpm == 'true' }}
         run: corepack prepare pnpm@${{ env.PNPM_VERSION }} --activate
-      - name: Configure pnpm home
-        if: ${{ steps.detect_pnpm.outputs.has-pnpm == 'true' }}
-        run: |
-          echo "PNPM_HOME=$HOME/.local/share/pnpm" >> "$GITHUB_ENV"
-          echo "$HOME/.local/share/pnpm" >> "$GITHUB_PATH"
-      - name: Set up pnpm
-        if: ${{ steps.detect_pnpm.outputs.has-pnpm == 'true' }}
-        uses: pnpm/action-setup@v4
-        with:
-          version: ${{ env.PNPM_VERSION }}
-          run_install: false
       - name: Show pnpm version
         if: ${{ steps.detect_pnpm.outputs.has-pnpm == 'true' }}
         run: pnpm --version

--- a/.github/workflows/guards.yml
+++ b/.github/workflows/guards.yml
@@ -41,6 +41,17 @@ jobs:
           "has-pnpm=$hasValue" | Out-File -FilePath $env:GITHUB_OUTPUT -Encoding utf8 -Append
           "project-dir=$projectDir" | Out-File -FilePath $env:GITHUB_OUTPUT -Encoding utf8 -Append
           "lock-path=$lockPath" | Out-File -FilePath $env:GITHUB_OUTPUT -Encoding utf8 -Append
+      - name: Configure pnpm home
+        if: ${{ steps.detect_pnpm.outputs.has-pnpm == 'true' }}
+        run: |
+          echo "PNPM_HOME=$HOME/.local/share/pnpm" >> "$GITHUB_ENV"
+          echo "$HOME/.local/share/pnpm" >> "$GITHUB_PATH"
+      - name: Install pnpm
+        if: ${{ steps.detect_pnpm.outputs.has-pnpm == 'true' }}
+        uses: pnpm/action-setup@v4
+        with:
+          version: ${{ env.PNPM_VERSION }}
+          run_install: false
       - name: Setup Node
         if: ${{ steps.detect_pnpm.outputs.has-pnpm == 'true' }}
         uses: actions/setup-node@v4
@@ -59,17 +70,6 @@ jobs:
       - name: Prepare pnpm
         if: ${{ steps.detect_pnpm.outputs.has-pnpm == 'true' }}
         run: corepack prepare pnpm@${{ env.PNPM_VERSION }} --activate
-      - name: Configure pnpm home
-        if: ${{ steps.detect_pnpm.outputs.has-pnpm == 'true' }}
-        run: |
-          echo "PNPM_HOME=$HOME/.local/share/pnpm" >> "$GITHUB_ENV"
-          echo "$HOME/.local/share/pnpm" >> "$GITHUB_PATH"
-      - name: Set up pnpm
-        if: ${{ steps.detect_pnpm.outputs.has-pnpm == 'true' }}
-        uses: pnpm/action-setup@v4
-        with:
-          version: ${{ env.PNPM_VERSION }}
-          run_install: false
       - name: Show pnpm version
         if: ${{ steps.detect_pnpm.outputs.has-pnpm == 'true' }}
         run: pnpm --version


### PR DESCRIPTION
Ref: docs/roadmap/step-02.02.md

## Summary
- install pnpm before calling setup-node caching to avoid missing binary failures

## Changes
- add pnpm/action-setup ahead of setup-node in the frontend test workflow
- mirror the pnpm installation order in the guards workflow

## Testing
- ⚠️ `pwsh -NoLogo -Command ./tools/guards/run_all_guards.ps1` *(indisponible: pwsh absent dans le conteneur CI)*

## Checklist
* [ ] Spec ajoutee/maj: docs/specs/spec-fonctionnelle-v0.1.md
* [ ] Agents referencent la SUT (SUT: docs/specs/spec-fonctionnelle-v0.1.md)
* [ ] Guards OK (docs_guard, roadmap_guard)
* [ ] Tests et lint OK

------
https://chatgpt.com/codex/tasks/task_e_68d58ac1ee3883309d18d46b2e1a7625