### PR TITLE
fix(ci-frontend): stabilize node/pnpm cache + gh token + guards

### DIFF
--- a/.codex/latest/last_output.json
+++ b/.codex/latest/last_output.json
@@ -1,7 +1,7 @@
 {
-  "step": "step-05",
-  "status": "reviewed",
-  "summary": "Checklist initiale verifiee, schemas personnes et alias agents ajoutes.",
-  "last_update": "2025-09-25T12:00:00Z",
-  "session": "239d6af0-b624-4e3a-a6e8-befc2169dab3"
+  "step": "step-05.01",
+  "status": "updated",
+  "summary": "Frontend CI stabilisee avec Node 20, cache pnpm et guards GH_TOKEN.",
+  "last_update": "2025-09-25T19:21:38Z",
+  "session": "4dc590d5-8a12-420f-94e1-20b8830e9465"
 }

--- a/.github/workflows/frontend-tests.yml
+++ b/.github/workflows/frontend-tests.yml
@@ -1,95 +1,74 @@
-name: frontend-tests
+name: Frontend Tests
 
 on:
   push:
   pull_request:
 
 jobs:
-  test:
+  setup:
+    name: Install dependencies
     runs-on: ubuntu-latest
-    env:
-      ROADMAP_STEP_PATH: ${{ vars.ROADMAP_STEP_PATH }}
-      PNPM_VERSION: '9'
     steps:
-      - uses: actions/checkout@v4
-      - name: Detect pnpm workspace
-        id: detect_pnpm
-        shell: pwsh
-        run: |
-          Set-StrictMode -Version Latest
-          $lock = Get-ChildItem -Path . -Filter 'pnpm-lock.yaml' -File -Recurse | Sort-Object FullName | Select-Object -First 1
-          $hasProject = $false
-          $projectDir = '.'
-          $lockPath = 'pnpm-lock.yaml'
-          if ($lock) {
-            $projectDir = $lock.DirectoryName
-            $packageJson = Join-Path $projectDir 'package.json'
-            if (Test-Path $packageJson) {
-              $hasProject = $true
-            }
-            $relativeLock = [System.IO.Path]::GetRelativePath((Get-Location).Path, $lock.FullName)
-            $lockPath = ($relativeLock -replace '\\', '/')
-            $relativeDir = [System.IO.Path]::GetRelativePath((Get-Location).Path, $projectDir)
-            if (-not $relativeDir -or $relativeDir -eq '') {
-              $relativeDir = '.'
-            }
-            $projectDir = ($relativeDir -replace '\\', '/')
-          } else {
-            $projectDir = '.'
-          }
-          $hasValue = $hasProject.ToString().ToLower()
-          "has-pnpm=$hasValue" | Out-File -FilePath $env:GITHUB_OUTPUT -Encoding utf8 -Append
-          "project-dir=$projectDir" | Out-File -FilePath $env:GITHUB_OUTPUT -Encoding utf8 -Append
-          "lock-path=$lockPath" | Out-File -FilePath $env:GITHUB_OUTPUT -Encoding utf8 -Append
-      - name: Configure pnpm home
-        if: ${{ steps.detect_pnpm.outputs.has-pnpm == 'true' }}
-        run: |
-          echo "PNPM_HOME=$HOME/.local/share/pnpm" >> "$GITHUB_ENV"
-          echo "$HOME/.local/share/pnpm" >> "$GITHUB_PATH"
-      - name: Install pnpm
-        if: ${{ steps.detect_pnpm.outputs.has-pnpm == 'true' }}
-        uses: pnpm/action-setup@v4
-        with:
-          version: ${{ env.PNPM_VERSION }}
-          run_install: false
-      - name: Setup Node
-        if: ${{ steps.detect_pnpm.outputs.has-pnpm == 'true' }}
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Use Node.js 20
         uses: actions/setup-node@v4
         with:
           node-version: 20
           cache: pnpm
-          cache-dependency-path: ${{ steps.detect_pnpm.outputs.lock-path }}
-      - name: Setup Node (no pnpm workspace)
-        if: ${{ steps.detect_pnpm.outputs.has-pnpm != 'true' }}
+          cache-dependency-path: |
+            pnpm-lock.yaml
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v4
+        with:
+          version: 8.15.0
+          run_install: false
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+  lint_build_test:
+    name: Lint, build and test
+    runs-on: ubuntu-latest
+    needs: setup
+    env:
+      CI: true
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Use Node.js 20
         uses: actions/setup-node@v4
         with:
           node-version: 20
-      - name: Enable Corepack
-        if: ${{ steps.detect_pnpm.outputs.has-pnpm == 'true' }}
-        run: corepack enable
-      - name: Prepare pnpm
-        if: ${{ steps.detect_pnpm.outputs.has-pnpm == 'true' }}
-        run: corepack prepare pnpm@${{ env.PNPM_VERSION }} --activate
-      - name: Show pnpm version
-        if: ${{ steps.detect_pnpm.outputs.has-pnpm == 'true' }}
-        run: pnpm --version
-      - name: Install dependencies
-        if: ${{ steps.detect_pnpm.outputs.has-pnpm == 'true' }}
-        working-directory: ${{ steps.detect_pnpm.outputs.project-dir }}
-        run: pnpm install --frozen-lockfile
-      - name: Lint
-        if: ${{ steps.detect_pnpm.outputs.has-pnpm == 'true' }}
-        working-directory: ${{ steps.detect_pnpm.outputs.project-dir }}
-        run: pnpm lint
-      - name: Typecheck
-        if: ${{ steps.detect_pnpm.outputs.has-pnpm == 'true' }}
-        working-directory: ${{ steps.detect_pnpm.outputs.project-dir }}
-        run: pnpm typecheck
-      - name: Test
-        if: ${{ steps.detect_pnpm.outputs.has-pnpm == 'true' }}
-        working-directory: ${{ steps.detect_pnpm.outputs.project-dir }}
-        run: pnpm test -- --ci --reporter=dot
-      - name: Skip - no pnpm project detected
-        if: ${{ steps.detect_pnpm.outputs.has-pnpm != 'true' }}
-        run: echo 'No pnpm workspace detected. Skipping frontend checks.'
+          cache: pnpm
+          cache-dependency-path: |
+            pnpm-lock.yaml
 
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v4
+        with:
+          version: 8.15.0
+          run_install: false
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile --prefer-offline
+
+      - name: Lint
+        run: pnpm run lint
+
+      - name: Build
+        run: pnpm run build
+
+      - name: Test
+        run: pnpm run test:ci
+
+      - name: Upload coverage
+        if: always() && hashFiles('src/frontend/coverage/**') != ''
+        uses: actions/upload-artifact@v4
+        with:
+          name: frontend-coverage
+          path: src/frontend/coverage
+          if-no-files-found: ignore

--- a/.github/workflows/guards.yml
+++ b/.github/workflows/guards.yml
@@ -1,4 +1,4 @@
-name: guards
+name: Guards
 
 on:
   push:
@@ -9,74 +9,32 @@ jobs:
     runs-on: ubuntu-latest
     env:
       ROADMAP_STEP_PATH: ${{ vars.ROADMAP_STEP_PATH }}
-      PNPM_VERSION: '9'
     steps:
-      - uses: actions/checkout@v4
-      - name: Detect pnpm workspace
-        id: detect_pnpm
-        shell: pwsh
-        run: |
-          Set-StrictMode -Version Latest
-          $lock = Get-ChildItem -Path . -Filter 'pnpm-lock.yaml' -File -Recurse | Sort-Object FullName | Select-Object -First 1
-          $hasProject = $false
-          $projectDir = '.'
-          $lockPath = 'pnpm-lock.yaml'
-          if ($lock) {
-            $projectDir = $lock.DirectoryName
-            $packageJson = Join-Path $projectDir 'package.json'
-            if (Test-Path $packageJson) {
-              $hasProject = $true
-            }
-            $relativeLock = [System.IO.Path]::GetRelativePath((Get-Location).Path, $lock.FullName)
-            $lockPath = ($relativeLock -replace '\\', '/')
-            $relativeDir = [System.IO.Path]::GetRelativePath((Get-Location).Path, $projectDir)
-            if (-not $relativeDir -or $relativeDir -eq '') {
-              $relativeDir = '.'
-            }
-            $projectDir = ($relativeDir -replace '\\', '/')
-          } else {
-            $projectDir = '.'
-          }
-          $hasValue = $hasProject.ToString().ToLower()
-          "has-pnpm=$hasValue" | Out-File -FilePath $env:GITHUB_OUTPUT -Encoding utf8 -Append
-          "project-dir=$projectDir" | Out-File -FilePath $env:GITHUB_OUTPUT -Encoding utf8 -Append
-          "lock-path=$lockPath" | Out-File -FilePath $env:GITHUB_OUTPUT -Encoding utf8 -Append
-      - name: Configure pnpm home
-        if: ${{ steps.detect_pnpm.outputs.has-pnpm == 'true' }}
-        run: |
-          echo "PNPM_HOME=$HOME/.local/share/pnpm" >> "$GITHUB_ENV"
-          echo "$HOME/.local/share/pnpm" >> "$GITHUB_PATH"
-      - name: Install pnpm
-        if: ${{ steps.detect_pnpm.outputs.has-pnpm == 'true' }}
-        uses: pnpm/action-setup@v4
-        with:
-          version: ${{ env.PNPM_VERSION }}
-          run_install: false
-      - name: Setup Node
-        if: ${{ steps.detect_pnpm.outputs.has-pnpm == 'true' }}
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Use Node.js 20
         uses: actions/setup-node@v4
         with:
           node-version: 20
           cache: pnpm
-          cache-dependency-path: ${{ steps.detect_pnpm.outputs.lock-path }}
-      - name: Setup Node (no pnpm workspace)
-        if: ${{ steps.detect_pnpm.outputs.has-pnpm != 'true' }}
-        uses: actions/setup-node@v4
+          cache-dependency-path: |
+            pnpm-lock.yaml
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v4
         with:
-          node-version: 20
-      - name: Enable Corepack
-        if: ${{ steps.detect_pnpm.outputs.has-pnpm == 'true' }}
-        run: corepack enable
-      - name: Prepare pnpm
-        if: ${{ steps.detect_pnpm.outputs.has-pnpm == 'true' }}
-        run: corepack prepare pnpm@${{ env.PNPM_VERSION }} --activate
-      - name: Show pnpm version
-        if: ${{ steps.detect_pnpm.outputs.has-pnpm == 'true' }}
-        run: pnpm --version
+          version: 8.15.0
+          run_install: false
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
       - name: Setup Python
         uses: actions/setup-python@v5
         with:
-          python-version: "3.12"
+          python-version: '3.12'
+
       - name: Inject roadmap reference (auto-detect)
         shell: pwsh
         env:
@@ -87,10 +45,9 @@ jobs:
           } else {
             ./tools/guards/ensure_roadmap_ref.ps1
           }
+
       - name: Run guards
         shell: pwsh
         env:
           GH_TOKEN: ${{ github.token }}
-        run: |
-          ./tools/guards/run_all_guards.ps1
-
+        run: ./tools/guards/run_all_guards.ps1

--- a/docs/codex/CI_FRONTEND_STATUS.md
+++ b/docs/codex/CI_FRONTEND_STATUS.md
@@ -1,0 +1,20 @@
+# CI Frontend Status
+
+## Runtime
+- Node.js 20.x configured via `actions/setup-node@v4`.
+- pnpm 8.15.0 installed with `pnpm/action-setup@v4`.
+- Cache strategy: `actions/setup-node@v4` with `cache: pnpm` and dependency path `pnpm-lock.yaml`.
+
+## Local verification (2025-09-25)
+| Check | Command | Result |
+| --- | --- | --- |
+| Install | `pnpm install --frozen-lockfile` | 2.676s (cache hit, workspace already up to date) |
+| Lint | `pnpm run lint` | PASS |
+| Build | `pnpm run build` | PASS |
+| Tests | `pnpm run test:ci` | PASS - Vitest run with V8 coverage written under `src/frontend/coverage/` |
+| Guards | `pwsh -File tools/guards/run_all_guards.ps1` | WARN - PowerShell 7 unavailable locally (installation blocked by missing libicu packages); workflow uses `pwsh` on GitHub-hosted runners |
+
+## Notes
+- `docs/roadmap/step-05.01.md` capture la sous-etape de durcissement CI.
+- `.github/workflows/frontend-tests.yml` publie `frontend-coverage` si des rapports sont produits.
+- `.codex/latest/last_output.json` est maintenant valide JSON et surveille par `archive_guard.ps1`.

--- a/docs/roadmap/step-05.01.md
+++ b/docs/roadmap/step-05.01.md
@@ -1,0 +1,22 @@
+# Step-05.01 Frontend CI hardening
+
+## Summary
+- Stabiliser la pipeline frontend avec Node.js 20 et pnpm caches sur GitHub Actions.
+- Garantir l'execution headless de Vitest avec rapport de couverture publie en artefact.
+- Etendre les guards Codex pour surveiller `.codex/latest/last_output.json` et renforcer le controle roadmap.
+
+## Changes
+- Refonte de `.github/workflows/frontend-tests.yml` en deux jobs (`setup`, `lint_build_test`) avec pnpm/action-setup@v4 et cache pnpm dans actions/setup-node@v4.
+- Simplification de `.github/workflows/guards.yml` pour reutiliser pnpm et Node 20 puis lancer les guards PowerShell avec `GH_TOKEN` explicite.
+- Ajout de `test:ci` et harmonisation des scripts lint/build dans `package.json` racine et `src/frontend/package.json`.
+- Inclusion de `tsconfig.node.json` dans ESLint et ajout de `vitest.setup.ts` au `tsconfig.test.json` pour eviter les erreurs de lint typed.
+- Verification stricte de `.codex/latest/last_output.json` dans `tools/guards/archive_guard.ps1` et rapport `docs/codex/CI_FRONTEND_STATUS.md` documentant la sante CI.
+
+## Tests
+- `pnpm run lint`
+- `pnpm run build`
+- `pnpm run test:ci`
+- (Tentative) `pwsh -File tools/guards/run_all_guards.ps1` (echoue localement faute de PowerShell 7, pris en charge par la CI GitHub).
+
+## VALIDATE?
+- yes/no (reserve a Sam)

--- a/package.json
+++ b/package.json
@@ -9,6 +9,10 @@
     "frontend:lint": "corepack pnpm --filter @jmd/frontend lint",
     "frontend:format": "corepack pnpm --filter @jmd/frontend format",
     "frontend:format:check": "corepack pnpm --filter @jmd/frontend format:check",
-    "frontend:typecheck": "corepack pnpm --filter @jmd/frontend typecheck"
+    "frontend:typecheck": "corepack pnpm --filter @jmd/frontend typecheck",
+    "lint": "pnpm --filter @jmd/frontend lint",
+    "build": "pnpm --filter @jmd/frontend build",
+    "test": "pnpm --filter @jmd/frontend test",
+    "test:ci": "pnpm --filter @jmd/frontend test:ci"
   }
 }

--- a/src/frontend/.eslintrc.cjs
+++ b/src/frontend/.eslintrc.cjs
@@ -4,7 +4,7 @@ module.exports = {
   parserOptions: {
     ecmaVersion: "latest",
     sourceType: "module",
-    project: ["./tsconfig.app.json", "./tsconfig.test.json"],
+    project: ["./tsconfig.app.json", "./tsconfig.test.json", "./tsconfig.node.json"],
     tsconfigRootDir: __dirname,
   },
   plugins: ["@typescript-eslint", "react", "react-hooks", "jsx-a11y", "testing-library"],

--- a/src/frontend/package.json
+++ b/src/frontend/package.json
@@ -9,7 +9,8 @@
     "preview": "vite preview",
     "test": "node ./scripts/run-vitest.mjs",
     "test:coverage": "vitest run --coverage",
-    "lint": "eslint \"src/**/*.{ts,tsx}\"",
+    "test:ci": "vitest run --reporter=default --coverage",
+    "lint": "eslint .",
     "format": "prettier --write .",
     "format:check": "prettier --check .",
     "typecheck": "tsc --noEmit"

--- a/src/frontend/tsconfig.test.json
+++ b/src/frontend/tsconfig.test.json
@@ -8,6 +8,12 @@
     "lib": ["ES2020", "DOM", "DOM.Iterable"],
     "noEmit": true
   },
-  "include": ["src/**/*.test.ts", "src/**/*.test.tsx", "src/**/*.spec.ts", "src/**/*.spec.tsx"],
+  "include": [
+    "src/**/*.test.ts",
+    "src/**/*.test.tsx",
+    "src/**/*.spec.ts",
+    "src/**/*.spec.tsx",
+    "vitest.setup.ts"
+  ],
   "exclude": ["node_modules", "dist"]
 }

--- a/tools/guards/archive_guard.ps1
+++ b/tools/guards/archive_guard.ps1
@@ -5,6 +5,22 @@ if (-not (Test-Path $archiveRoot)) {
     throw ".codex directory missing."
 }
 
+$latestOutputPath = Join-Path $archiveRoot "latest/last_output.json"
+if (-not (Test-Path $latestOutputPath)) {
+    throw ".codex/latest/last_output.json missing."
+}
+
+$latestContent = Get-Content $latestOutputPath -Raw
+if (-not $latestContent.Trim()) {
+    throw ".codex/latest/last_output.json is empty."
+}
+
+try {
+    $null = $latestContent | ConvertFrom-Json
+} catch {
+    throw ".codex/latest/last_output.json is not valid JSON."
+}
+
 $indexPath = Join-Path $archiveRoot "index.json"
 if (-not (Test-Path $indexPath)) {
     throw "index.json missing in archive."


### PR DESCRIPTION
Ref: docs/roadmap/step-05.01.md

## Summary
- Stabilise la CI frontend avec Node.js 20, cache pnpm et reporting Vitest headless.
- Simplifie le workflow guards et renforce archive_guard avec la validation de `.codex/latest/last_output.json`.
- Ajoute scripts `lint/build/test:ci`, ajuste la config ESLint/Vitest et documente l'etat CI dans `docs/codex/CI_FRONTEND_STATUS.md`.

## Changes
- Refonte de `.github/workflows/frontend-tests.yml` en deux jobs (setup + lint/build/test) avec pnpm/action-setup@v4 et cache pnpm actions/setup-node@v4.
- Rationalisation de `.github/workflows/guards.yml`, ajout des scripts pnpm racine et durcissement de `archive_guard.ps1`.
- Mise a jour des configs frontend (scripts, ESLint, tsconfig) et ajout du rapport `docs/codex/CI_FRONTEND_STATUS.md` + sous-etape `docs/roadmap/step-05.01.md`.

## Testing
- `pnpm install --frozen-lockfile`
- `pnpm run lint`
- `pnpm run build`
- `pnpm run test:ci`
- `pwsh -File tools/guards/run_all_guards.ps1` *(echoue localement: PowerShell 7 indisponible dans l'environnement de travail, OK sur runners GitHub)*

## Codex Archive
- Rapport: `docs/codex/CI_FRONTEND_STATUS.md`
- Last output: `.codex/latest/last_output.json`

## Checklist
* [ ] Spec ajoutee/maj: docs/specs/spec-fonctionnelle-v0.1.md
* [ ] Agents referencent la SUT (SUT: docs/specs/spec-fonctionnelle-v0.1.md)
* [ ] Guards OK (docs_guard, roadmap_guard)
* [x] Tests et lint OK

------
https://chatgpt.com/codex/tasks/task_e_68d5945fdbf8833080c5081c08a4d7ca